### PR TITLE
Fix #95 アセンブリメタデータと新しいプロパティ・コマンドの追加

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,4 +19,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugType>embedded</DebugType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BuildDateTime</_Parameter1>
+      <_Parameter2>$([System.DateTime]::UtcNow.ToString("o"))</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/WindowTranslator/Properties/Resources.Designer.cs
+++ b/WindowTranslator/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace WindowTranslator.Properties {
         }
         
         /// <summary>
+        ///   このアプリについて に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string About {
+            get {
+                return ResourceManager.GetString("About", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   アタッチ に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Attach {
@@ -165,6 +174,15 @@ namespace WindowTranslator.Properties {
         public static string MutexError {
             get {
                 return ResourceManager.GetString("MutexError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   サードパーティーライセンスの確認 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string OpenThirdPartyLicensesCommand {
+            get {
+                return ResourceManager.GetString("OpenThirdPartyLicensesCommand", resourceCulture);
             }
         }
         

--- a/WindowTranslator/Properties/Resources.de.resx
+++ b/WindowTranslator/Properties/Resources.de.resx
@@ -186,4 +186,10 @@
   <data name="MutexError" xml:space="preserve">
     <value>Der WindowTranslator läuft bereits.</value>
   </data>
+  <data name="About" xml:space="preserve">
+    <value>Über</value>
+  </data>
+  <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
+    <value>Lizenzen von Drittanbietern prüfen</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.en.resx
+++ b/WindowTranslator/Properties/Resources.en.resx
@@ -186,4 +186,10 @@
   <data name="MutexError" xml:space="preserve">
     <value>WindowTranslator is already running.</value>
   </data>
+  <data name="About" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
+    <value>Check third party licenses</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.ko.resx
+++ b/WindowTranslator/Properties/Resources.ko.resx
@@ -186,4 +186,10 @@
   <data name="MutexError" xml:space="preserve">
     <value>WindowTranslator가 이미 실행 중입니다.</value>
   </data>
+  <data name="About" xml:space="preserve">
+    <value>정보</value>
+  </data>
+  <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
+    <value>타사 라이선스 확인</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.resx
+++ b/WindowTranslator/Properties/Resources.resx
@@ -186,4 +186,10 @@
   <data name="MutexError" xml:space="preserve">
     <value>すでにWindowTranslatorが起動中です</value>
   </data>
+  <data name="About" xml:space="preserve">
+    <value>このアプリについて</value>
+  </data>
+  <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
+    <value>サードパーティーライセンスの確認</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.zh-CN.resx
+++ b/WindowTranslator/Properties/Resources.zh-CN.resx
@@ -186,4 +186,10 @@
   <data name="MutexError" xml:space="preserve">
     <value>WindowTranslator 已在运行。</value>
   </data>
+  <data name="About" xml:space="preserve">
+    <value>关于</value>
+  </data>
+  <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
+    <value>检查第三方许可证</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.zh-TW.resx
+++ b/WindowTranslator/Properties/Resources.zh-TW.resx
@@ -186,4 +186,10 @@
   <data name="MutexError" xml:space="preserve">
     <value>WindowTranslator 已在執行中。</value>
   </data>
+  <data name="About" xml:space="preserve">
+    <value>關於</value>
+  </data>
+  <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
+    <value>檢查第三方授權</value>
+  </data>
 </root>


### PR DESCRIPTION
`Directory.Build.props` に `ItemGroup` を追加し、ビルド日時を含むメタデータをアセンブリに追加する設定を追加しました。`SettingsViewModel.cs` に新しいプロパティ (`App`, `BuildDate`, `DevelopedBy`, `Link`, `License`) とコマンド ( `OpenThirdPartyLicenses`) を追加しました。`Resources.Designer.cs` と各言語リソースファイルに新しいローカライズされた文字列 (`About`, `OpenThirdPartyLicensesCommand`) を追加しました。