### PR TITLE
Fix #19 更新チェック機能の追加とリファクタリング

### DIFF
--- a/WindowTranslator/App.xaml.cs
+++ b/WindowTranslator/App.xaml.cs
@@ -12,10 +12,21 @@ public partial class App : Application
 #pragma warning disable IDE0052 // WinUIのコントロール使うために初期化する必要がある
     private readonly DispatcherQueueController? controller;
 #pragma warning restore IDE0052
+    private readonly TaskCompletionSource tcs = new();
 
     public App()
     {
         this.controller = CoreMessagingHelper.CreateDispatcherQueueControllerForCurrentThread();
         InitializeComponent();
     }
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        this.tcs.SetResult();
+    }
+
+    public Task WaitForStartupAsync()
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+        => this.tcs.Task;
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 }

--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -71,6 +71,9 @@ builder.Configuration
 builder.Services.AddSingleton<IMainWindowModule, MainWindowModule>();
 builder.Services.AddSingleton<ITargetStore, TargetStore>();
 builder.Services.AddHostedService<WindowMonitor>();
+builder.Services.AddSingleton<UpdateChecker>()
+    .AddSingleton<IUpdateChecker>(sp => sp.GetRequiredService<UpdateChecker>())
+    .AddHostedService(sp => sp.GetRequiredService<UpdateChecker>());
 builder.Services.AddScoped<IProcessInfoStore, ProcessInfoStore>();
 builder.Services.AddPresentation<StartupDialog, StartupViewModel>();
 builder.Services.AddPresentation<CaptureMainWindow, CaptureMainViewModel>();

--- a/WindowTranslator/Properties/Resources.Designer.cs
+++ b/WindowTranslator/Properties/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace WindowTranslator.Properties {
         }
         
         /// <summary>
+        ///   アップデートがあります: {0} に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string HasUpdate {
+            get {
+                return ResourceManager.GetString("HasUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   メモリ内キャッシュ に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string InMemoryCache {
@@ -138,6 +147,15 @@ namespace WindowTranslator.Properties {
         public static string IsEnableAutoTarget {
             get {
                 return ResourceManager.GetString("IsEnableAutoTarget", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   最新バージョンをご利用中です。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string IsLatest {
+            get {
+                return ResourceManager.GetString("IsLatest", resourceCulture);
             }
         }
         
@@ -174,6 +192,15 @@ namespace WindowTranslator.Properties {
         public static string MutexError {
             get {
                 return ResourceManager.GetString("MutexError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   詳細情報の確認 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string OpenChangelogCommand {
+            get {
+                return ResourceManager.GetString("OpenChangelogCommand", resourceCulture);
             }
         }
         
@@ -273,6 +300,24 @@ namespace WindowTranslator.Properties {
         public static string UnregisterFromStartupCommand {
             get {
                 return ResourceManager.GetString("UnregisterFromStartupCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   最新バージョンに更新 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UpdateCommand {
+            get {
+                return ResourceManager.GetString("UpdateCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   更新情報 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UpdateInfo {
+            get {
+                return ResourceManager.GetString("UpdateInfo", resourceCulture);
             }
         }
         

--- a/WindowTranslator/Properties/Resources.de.resx
+++ b/WindowTranslator/Properties/Resources.de.resx
@@ -192,4 +192,19 @@
   <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
     <value>Lizenzen von Drittanbietern prüfen</value>
   </data>
+  <data name="OpenChangelogCommand" xml:space="preserve">
+    <value>Details prüfen</value>
+  </data>
+  <data name="UpdateCommand" xml:space="preserve">
+    <value>Update auf die neueste Version</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>Aktualisierte Informationen</value>
+  </data>
+  <data name="IsLatest" xml:space="preserve">
+    <value>Sie verwenden die neueste Version.</value>
+  </data>
+  <data name="HasUpdate" xml:space="preserve">
+    <value>Updates verfügbar: {0}</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.en.resx
+++ b/WindowTranslator/Properties/Resources.en.resx
@@ -192,4 +192,19 @@
   <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
     <value>Check third party licenses</value>
   </data>
+  <data name="OpenChangelogCommand" xml:space="preserve">
+    <value>Check details</value>
+  </data>
+  <data name="UpdateCommand" xml:space="preserve">
+    <value>Update to latest version</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>Update Information</value>
+  </data>
+  <data name="IsLatest" xml:space="preserve">
+    <value>You are using the latest version.</value>
+  </data>
+  <data name="HasUpdate" xml:space="preserve">
+    <value>Updates available: {0}</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.ko.resx
+++ b/WindowTranslator/Properties/Resources.ko.resx
@@ -192,4 +192,19 @@
   <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
     <value>타사 라이선스 확인</value>
   </data>
+  <data name="OpenChangelogCommand" xml:space="preserve">
+    <value>세부 정보 확인</value>
+  </data>
+  <data name="UpdateCommand" xml:space="preserve">
+    <value>최신 버전으로 업데이트</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>업데이트 정보</value>
+  </data>
+  <data name="IsLatest" xml:space="preserve">
+    <value>최신 버전을 사용하고 있습니다.</value>
+  </data>
+  <data name="HasUpdate" xml:space="preserve">
+    <value>업데이트를 사용할 수 있습니다: {0}</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.resx
+++ b/WindowTranslator/Properties/Resources.resx
@@ -192,4 +192,19 @@
   <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
     <value>サードパーティーライセンスの確認</value>
   </data>
+  <data name="HasUpdate" xml:space="preserve">
+    <value>アップデートがあります: {0}</value>
+  </data>
+  <data name="IsLatest" xml:space="preserve">
+    <value>最新バージョンをご利用中です。</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>更新情報</value>
+  </data>
+  <data name="UpdateCommand" xml:space="preserve">
+    <value>最新バージョンに更新</value>
+  </data>
+  <data name="OpenChangelogCommand" xml:space="preserve">
+    <value>詳細情報の確認</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.zh-CN.resx
+++ b/WindowTranslator/Properties/Resources.zh-CN.resx
@@ -192,4 +192,19 @@
   <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
     <value>检查第三方许可证</value>
   </data>
+  <data name="OpenChangelogCommand" xml:space="preserve">
+    <value>查看详细信息</value>
+  </data>
+  <data name="UpdateCommand" xml:space="preserve">
+    <value>更新至最新版本</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>更新信息</value>
+  </data>
+  <data name="IsLatest" xml:space="preserve">
+    <value>您使用的是最新版本。</value>
+  </data>
+  <data name="HasUpdate" xml:space="preserve">
+    <value>可用更新： {0}</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.zh-TW.resx
+++ b/WindowTranslator/Properties/Resources.zh-TW.resx
@@ -192,4 +192,19 @@
   <data name="OpenThirdPartyLicensesCommand" xml:space="preserve">
     <value>檢查第三方授權</value>
   </data>
+  <data name="OpenChangelogCommand" xml:space="preserve">
+    <value>檢查詳細資料</value>
+  </data>
+  <data name="UpdateCommand" xml:space="preserve">
+    <value>更新至最新版本</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>更新資訊</value>
+  </data>
+  <data name="IsLatest" xml:space="preserve">
+    <value>您使用的是最新版本。</value>
+  </data>
+  <data name="HasUpdate" xml:space="preserve">
+    <value>可用的更新： {0}</value>
+  </data>
 </root>

--- a/WindowTranslator/UpdateChecker.cs
+++ b/WindowTranslator/UpdateChecker.cs
@@ -1,0 +1,280 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Toolkit.Uwp.Notifications;
+using Octokit;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.Json;
+using Windows.UI.Notifications;
+
+namespace WindowTranslator;
+
+internal class UpdateChecker : BackgroundService, IUpdateChecker
+{
+    private const string owner = "Freeesia";
+    private static readonly string updateInfoPath = Path.Combine(PathUtility.UserDir, "update.json");
+    private readonly GitHubClient client;
+    private readonly string name;
+    private readonly Version version;
+    private readonly ILogger<UpdateChecker> logger;
+    private readonly App app;
+
+    private bool hasUpdate;
+
+    public event EventHandler? UpdateAvailable;
+
+    public bool HasUpdate
+    {
+        get => this.hasUpdate;
+        private set
+        {
+            if (this.hasUpdate != value)
+            {
+                this.hasUpdate = value;
+                this.UpdateAvailable?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    public string? LatestVersion { get; private set; }
+
+    public UpdateChecker(ILogger<UpdateChecker> logger, App app)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var name = assembly.GetName();
+        this.name = name.Name ?? throw new InvalidOperationException();
+        this.version = name.Version ?? throw new InvalidOperationException();
+        this.client = new(new ProductHeaderValue(this.name, this.version.ToString()));
+        this.logger = logger;
+        this.app = app;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+
+        await this.app.WaitForStartupAsync();
+        ToastNotificationManagerCompat.OnActivated += ToastNotificationManagerCompat_OnActivated;
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await CheckAndDownloadAsync(stoppingToken);
+                await Task.Delay(TimeSpan.FromDays(1), stoppingToken);
+            }
+        }
+        finally
+        {
+            ToastNotificationManagerCompat.History.Clear();
+            ToastNotificationManagerCompat.Uninstall();
+        }
+    }
+
+    private async ValueTask CheckAndDownloadAsync(CancellationToken stoppingToken)
+    {
+        var updateInfo = await LoadUpdateInfoAsync().ConfigureAwait(false);
+
+        // 更新情報がない場合は最新のリリースを取得
+        // 1日以上経過していたら最新のリリースを取得
+        if (updateInfo is null || updateInfo.CheckedAt < DateTime.UtcNow.AddDays(-1))
+        {
+            var release = await this.client.Repository.Release.GetLatest(owner, this.name);
+            stoppingToken.ThrowIfCancellationRequested();
+            var version = release.Name.TrimStart('v');
+
+            if (new Version(version) <= this.version)
+            {
+                this.logger.LogInformation("アプリケーションは最新のバージョンです。");
+                await SaveUpdateInfoAsync(new(version, release.HtmlUrl, null, DateTime.UtcNow, false)).ConfigureAwait(false);
+                return;
+            }
+            this.logger.LogInformation($"新しいバージョン {version} が利用可能です。");
+            var asset = release.Assets.FirstOrDefault(a => a.Name.EndsWith(".msi", StringComparison.OrdinalIgnoreCase));
+            if (asset is null)
+            {
+                this.logger.LogWarning("インストーラーが見つかりませんでした。");
+                return;
+            }
+            string installerUrl = asset.BrowserDownloadUrl;
+
+            // インストーラーをダウンロードして実行
+            var dir = Path.Combine(Path.GetTempPath(), this.name);
+            string installerPath = Path.Combine(dir, asset.Name);
+            if (File.Exists(installerPath))
+            {
+                this.logger.LogInformation("インストーラーはすでにダウンロードされています。");
+            }
+            else
+            {
+                Directory.CreateDirectory(dir);
+                using var downloader = new HttpClient();
+                using var fs = File.Create(installerPath);
+                using var stream = await downloader.GetStreamAsync(installerUrl, stoppingToken);
+                await stream.CopyToAsync(fs, stoppingToken);
+                this.logger.LogInformation("インストーラーをダウンロードしました。");
+            }
+            await SaveUpdateInfoAsync(new(version, release.HtmlUrl, installerPath, DateTime.UtcNow, false)).ConfigureAwait(false);
+            ShowUpdateNotification(version, release.HtmlUrl, installerPath, false);
+            this.LatestVersion = version;
+            this.HasUpdate = true;
+        }
+        // バージョンが新しい場合は通知
+        else if (new Version(updateInfo.Version) > this.version && !updateInfo.Skip && updateInfo.Path is not null && File.Exists(updateInfo.Path))
+        {
+            ShowUpdateNotification(updateInfo.Version, updateInfo.Url, updateInfo.Path, false);
+            this.LatestVersion = updateInfo.Version;
+            this.HasUpdate = true;
+        }
+    }
+
+    private static void ShowUpdateNotification(string version, string url, string path, bool supress)
+    {
+        var builder = new ToastContentBuilder()
+            .AddText($"新しいバージョン {version} がリリースされました", AdaptiveTextStyle.Title)
+            .AddText($"更新版をインストールしますか？")
+            .AddArgument(nameof(UpdateChecker))
+            .AddArgument(nameof(url), url)
+            .AddArgument(nameof(path), path)
+            .AddArgument(nameof(version), version)
+            .AddButton(new ToastButton()
+                .AddArgument("action", ToastActions.Install)
+                .SetContent("インストール"))
+            .AddButton(new ToastButton()
+                .SetContent("更新内容の確認")
+                .AddArgument("action", ToastActions.OpenBrowser)
+                .SetBackgroundActivation());
+
+        {
+            var args = ToastArguments.Parse(builder.Content.Launch);
+            args.Add("action", ToastActions.Skip);
+            builder.Content.Actions.ContextMenuItems.Add(new("このバージョンをスキップ", args.ToString()));
+        }
+
+        builder.Show(t =>
+        {
+            t.ExpiresOnReboot = true;
+            t.NotificationMirroring = NotificationMirroring.Disabled;
+            t.SuppressPopup = supress;
+        });
+    }
+
+    private async void ToastNotificationManagerCompat_OnActivated(ToastNotificationActivatedEventArgsCompat e)
+    {
+        var args = ToastArguments.Parse(e.Argument);
+        if (!args.Contains(nameof(UpdateChecker)))
+        {
+            return;
+        }
+        if (!args.TryGetValue<ToastActions>("action", out var action))
+        {
+            this.app.Dispatcher.Invoke(this.app.MainWindow.Show);
+            return;
+        }
+        switch (action)
+        {
+            case ToastActions.Install:
+                Process.Start("msiexec", $"/i {args.Get("path")}");
+                break;
+            case ToastActions.Skip:
+                await SaveUpdateInfoAsync(new(args.Get("version"), args.Get("url"), args.Get("path"), DateTime.UtcNow, true)).ConfigureAwait(false);
+                break;
+            case ToastActions.OpenBrowser:
+                Process.Start(new ProcessStartInfo(args.Get("url")) { UseShellExecute = true });
+                ShowUpdateNotification(args.Get("version"), args.Get("url"), args.Get("path"), true);
+                break;
+            default:
+                break;
+        }
+    }
+
+    public async Task CheckAsync(CancellationToken token)
+    {
+        var updateInfo = await LoadUpdateInfoAsync();
+        if (updateInfo is null)
+        {
+            await CheckAndDownloadAsync(token).ConfigureAwait(false);
+        }
+        else if (new Version(updateInfo.Version) > this.version && !updateInfo.Skip && updateInfo.Path is not null && File.Exists(updateInfo.Path))
+        {
+            ShowUpdateNotification(updateInfo.Version, updateInfo.Url, updateInfo.Path, false);
+            this.LatestVersion = updateInfo.Version;
+            this.HasUpdate = true;
+        }
+        else
+        {
+            await SaveUpdateInfoAsync(updateInfo with { CheckedAt = DateTime.MinValue, Skip = false }).ConfigureAwait(false);
+            await CheckAndDownloadAsync(token).ConfigureAwait(false);
+        }
+    }
+
+    public async void Update()
+    {
+        var updateInfo = await LoadUpdateInfoAsync().ConfigureAwait(false);
+        if (updateInfo is not null && updateInfo.Path is not null && File.Exists(updateInfo.Path))
+        {
+            Process.Start("msiexec", $"/i {updateInfo.Path}");
+        }
+    }
+
+    public async void OpenChangelog()
+    {
+        var updateInfo = await LoadUpdateInfoAsync().ConfigureAwait(false);
+        if (updateInfo is not null)
+        {
+            Process.Start(new ProcessStartInfo(updateInfo.Url) { UseShellExecute = true });
+        }
+    }
+
+    private enum ToastActions
+    {
+        Install,
+        Skip,
+        OpenBrowser
+    }
+
+    private async ValueTask<UpdateInfo?> LoadUpdateInfoAsync()
+    {
+        try
+        {
+            if (File.Exists(updateInfoPath))
+            {
+                using var fs = File.OpenRead(updateInfoPath);
+                return await JsonSerializer.DeserializeAsync<UpdateInfo>(fs).ConfigureAwait(false);
+            }
+        }
+        catch (Exception e)
+        {
+            this.logger.LogError(e, "更新情報の読み込みに失敗しました");
+        }
+        return null;
+    }
+
+    private async ValueTask SaveUpdateInfoAsync(UpdateInfo updateInfo)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(updateInfoPath)!);
+            using var fs = File.Create(updateInfoPath);
+            await JsonSerializer.SerializeAsync(fs, updateInfo).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            this.logger.LogError("更新情報の保存に失敗しました");
+        }
+    }
+}
+
+interface IUpdateChecker
+{
+    bool HasUpdate { get; }
+    string? LatestVersion { get; }
+
+    event EventHandler? UpdateAvailable;
+
+    Task CheckAsync(CancellationToken token);
+    void Update();
+    void OpenChangelog();
+}
+
+record UpdateInfo(string Version, string Url, string? Path, DateTime CheckedAt, bool Skip);

--- a/WindowTranslator/WindowMonitor.cs
+++ b/WindowTranslator/WindowMonitor.cs
@@ -91,6 +91,7 @@ public class WindowMonitor(IMainWindowModule mainWindowModule, ITargetStore auto
         var builder = new ToastContentBuilder()
             .AddText("翻訳対象アプリが見つかりました")
             .AddText($"「{windowTitle}」を翻訳表示しますか？")
+            .AddArgument(nameof(WindowMonitor))
             .AddArgument(ProcessName, process.ProcessName)
             .AddArgument(WindowHandle, windowHandle.ToString(CultureInfo.InvariantCulture))
             .AddButton(new ToastButton()
@@ -141,6 +142,10 @@ public class WindowMonitor(IMainWindowModule mainWindowModule, ITargetStore auto
     private async void ToastNotificationManagerCompat_OnActivated(ToastNotificationActivatedEventArgsCompat e)
     {
         var args = ToastArguments.Parse(e.Argument);
+        if (!args.Contains(nameof(WindowMonitor)))
+        {
+            return;
+        }
         var processName = args.Get(ProcessName);
         var mainWindowHandle = IntPtr.Parse(args.Get(WindowHandle), CultureInfo.InvariantCulture);
         this.logger.LogInformation("通知からのアタッチ");

--- a/WindowTranslator/WindowTranslator.csproj
+++ b/WindowTranslator/WindowTranslator.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.4" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="PInvoke.SHCore" Version="0.7.124" />
     <PackageReference Include="PInvoke.User32" Version="0.7.124" />
     <PackageReference Include="PropertyTools.Wpf" Version="3.1.0" />


### PR DESCRIPTION
- `App.xaml.cs` に `OnStartup` と `WaitForStartupAsync` メソッドを追加し、アプリ起動完了を待機する機能を追加
- `SettingsViewModel.cs` で `Microsoft.PowerShell` と `System.Reflection.Metadata` の使用を削除し、`WindowTranslator.Properties` を追加
- `SettingsViewModel` に `HasUpdate` と `UpdateInfo` プロパティを追加し、更新情報を表示する機能を追加
- `SettingsViewModel` のコンストラクタに `IUpdateChecker` を追加し、更新チェック機能を統合
- `SettingsViewModel` に `OpenChangelog` と `Update` コマンドを追加し、更新情報の表示と更新の実行を可能に
- `Program.cs` に `UpdateChecker` サービスを追加し、更新チェック機能をアプリに統合
- `Resources.Designer.cs` と各言語のリソースファイルに更新関連のローカライズ文字列を追加
- `WindowMonitor.cs` に通知の引数チェックを追加し、特定の引数が含まれていない場合の処理を中断
- `WindowTranslator.csproj` に `Octokit` パッケージを追加し、GitHub API の依存関係を追加
- `UpdateChecker.cs` を新規追加し、GitHub リリースをチェックして更新を通知する機能を実装