### PR TITLE
Win + Alt + O を押している間だけオーバーレイ表示を消す機能追加

### DIFF
--- a/WindowTranslator/Modules/Main/OverlayMainWindow.xaml
+++ b/WindowTranslator/Modules/Main/OverlayMainWindow.xaml
@@ -32,6 +32,7 @@
     </Window.Resources>
     <Canvas>
         <control:OverlayTextsControl
+            x:Name="overlay"
             MousePos="{Binding MousePos, ElementName=host, Mode=OneWay}"
             RectHeight="{Binding Height}"
             RectWidth="{Binding Width}"

--- a/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
+++ b/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
@@ -1,12 +1,15 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Threading;
 using PInvoke;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
 using WindowTranslator.Stores;
+using static Windows.Win32.PInvoke;
 using static PInvoke.User32;
 
 namespace WindowTranslator.Modules.Main;
@@ -75,6 +78,11 @@ public partial class OverlayMainWindow : Window
         // 2回呼ばないと安定して最上位にならない
         SetWindowPos(hWndHiddenOwner, new(-1), 0, 0, 0, 0, SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOACTIVATE);
         this.timer.Start();
+
+        RegisterHotKey(new(this.windowHandle), 0, HOT_KEY_MODIFIERS.MOD_WIN | HOT_KEY_MODIFIERS.MOD_ALT, (uint)KeyInterop.VirtualKeyFromKey(Key.O));
+        var source = HwndSource.FromHwnd(this.windowHandle);
+        source.AddHook(WndProc);
+
     }
 
     protected override void OnClosed(EventArgs e)
@@ -122,5 +130,16 @@ public partial class OverlayMainWindow : Window
         this.SetCurrentValue(HeightProperty, height / eDpiScale);
         this.SetCurrentValue(MousePosProperty, new Point(x, y));
         this.logger.LogDebug($"Window: (x:{left:f2}, y:{top:f2}, w:{width:f2}, h:{height:f2}), マウス位置：({x:f2}, {y:f2} {sw.Elapsed}");
+    }
+
+    private nint WndProc(nint hwnd, int msg, nint wParam, nint lParam, ref bool handled)
+    {
+        if (msg != WM_HOTKEY)
+        {
+            return 0;
+        }
+
+        this.overlay.SetCurrentValue(VisibilityProperty, this.overlay.Visibility == Visibility.Visible ? Visibility.Hidden : Visibility.Visible);
+        return 0;
     }
 }

--- a/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
+++ b/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
@@ -24,6 +24,7 @@ public partial class OverlayMainWindow : Window
     private readonly DispatcherTimer timer = new();
     private readonly ILogger<OverlayMainWindow> logger;
     private IntPtr windowHandle;
+    private int overlayHiddenCount;
 
     public Point MousePos
     {
@@ -139,7 +140,18 @@ public partial class OverlayMainWindow : Window
             return 0;
         }
 
-        this.overlay.SetCurrentValue(VisibilityProperty, this.overlay.Visibility == Visibility.Visible ? Visibility.Hidden : Visibility.Visible);
+        HideOverlay();
         return 0;
+    }
+
+    private async void HideOverlay()
+    {
+        var current = Interlocked.Increment(ref this.overlayHiddenCount);
+        this.overlay.SetCurrentValue(VisibilityProperty, Visibility.Hidden);
+        await Task.Delay(500);
+        if (Interlocked.CompareExchange(ref this.overlayHiddenCount, 0, current) == current)
+        {
+            this.overlay.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+        }
     }
 }

--- a/WindowTranslator/NativeMethods.txt
+++ b/WindowTranslator/NativeMethods.txt
@@ -1,0 +1,3 @@
+﻿RegisterHotKey
+UnregisterHotKey
+WM_HOTKEY

--- a/WindowTranslator/WindowTranslator.csproj
+++ b/WindowTranslator/WindowTranslator.csproj
@@ -45,7 +45,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Octokit" Version="13.0.1" />
-    <PackageReference Include="PInvoke.SHCore" Version="0.7.124" />
     <PackageReference Include="PInvoke.User32" Version="0.7.124" />
     <PackageReference Include="PropertyTools.Wpf" Version="3.1.0" />
     <PackageReference Include="Sentry.Extensions.Logging" Version="4.10.1" />

--- a/WindowTranslator/WindowTranslator.csproj
+++ b/WindowTranslator/WindowTranslator.csproj
@@ -40,6 +40,10 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.4" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="PInvoke.SHCore" Version="0.7.124" />
     <PackageReference Include="PInvoke.User32" Version="0.7.124" />


### PR DESCRIPTION
#### PR Classification
Win + Alt + O を押している間だけオーバーレイ表示を消す機能追加

#### PR Summary
- `OverlayMainWindow.xaml` に改行を追加
- `OverlayMainWindow.xaml.cs` にホットキー登録とウィンドウプロシージャのフックを追加
- `NativeMethods.txt` にホットキー関連のメソッドを追加
- `WindowTranslator.csproj` に `Microsoft.Windows.CsWin32` パッケージを追加し、`PInvoke.SHCore` パッケージを削除
