### PR TITLE
ライトテーマで設定ダイアログの内容が見えない問題修正

### DIFF
--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Shell;
 using Weikio.PluginFramework.Abstractions;
 using Weikio.PluginFramework.Catalogs;
 using WindowTranslator;
@@ -26,7 +25,6 @@ using WindowTranslator.Properties;
 using WindowTranslator.Stores;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
-using Wpf.Ui.Interop;
 using Button = System.Windows.Controls.Button;
 
 //Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo("zh-CN");

--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Shell;
 using Weikio.PluginFramework.Abstractions;
 using Weikio.PluginFramework.Catalogs;
 using WindowTranslator;
@@ -25,6 +26,7 @@ using WindowTranslator.Properties;
 using WindowTranslator.Stores;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
+using Wpf.Ui.Interop;
 using Button = System.Windows.Controls.Button;
 
 //Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo("zh-CN");
@@ -85,12 +87,10 @@ builder.Services.AddTransient(_ =>
     dlg.ShowInTaskbar = true;
     dlg.PropertyControl.SetCurrentValue(PropertyGrid.OperatorProperty, new SettingsPropertyGridOperator());
     dlg.PropertyControl.SetCurrentValue(PropertyGrid.ControlFactoryProperty, new SettingsPropertyGridFactory());
-    dlg.SetResourceReference(Control.BackgroundProperty, "ApplicationBackgroundBrush");
-    dlg.SetResourceReference(FrameworkElement.StyleProperty, "UiWindow");
+    dlg.SetResourceReference(FrameworkElement.StyleProperty, "DefaultWindowStyle");
     dlg.Resources.Remove(typeof(Button));
     dlg.SetCurrentValue(Window.WindowStyleProperty, WindowStyle.None);
     dlg.SetCurrentValue(Window.TitleProperty, string.Empty);
-    WindowBackgroundManager.UpdateBackground(dlg, ApplicationTheme.Dark, WindowBackdropType.Mica);
     var btnStyle = new Style(typeof(Button), (Style)Application.Current.FindResource(typeof(Button)));
     btnStyle.Setters.Add(new Setter(FrameworkElement.MinWidthProperty, 120d));
     btnStyle.Setters.Add(new Setter(Control.PaddingProperty, new Thickness(8)));
@@ -102,6 +102,7 @@ builder.Services.AddTransient(_ =>
     DockPanel.SetDock(bar, Dock.Top);
     panel.Children.Insert(0, bar);
     SystemThemeWatcher.Watch(dlg);
+    dlg.Loaded += static (_, _) => ApplicationThemeManager.ApplySystemTheme(true);
     return dlg;
 });
 builder.Services.AddTransient<SettingsViewModel>();


### PR DESCRIPTION
#### PR Classification
ダイアログの背景とスタイルの変更、およびシステムテーマの適用。

#### PR Summary
ダイアログの背景設定とスタイルを変更し、ロード時にシステムテーマを適用するようにしました。
- `dlg.SetResourceReference(Control.BackgroundProperty, "ApplicationBackgroundBrush");` と `WindowBackgroundManager.UpdateBackground(dlg, ApplicationTheme.Dark, WindowBackdropType.Mica);` の削除
- `dlg.SetResourceReference(FrameworkElement.StyleProperty, "UiWindow");` を `dlg.SetResourceReference(FrameworkElement.StyleProperty, "DefaultWindowStyle");` に変更
- `dlg.Loaded += static (_, _) => ApplicationThemeManager.ApplySystemTheme(true);` の追加
