### PR TITLE
FoM専用機能の無効化と更新確認機能の追加

### DIFF
--- a/Plugins/WindowTranslator.Plugin.FoMPlugin/FoMFilterModule.cs
+++ b/Plugins/WindowTranslator.Plugin.FoMPlugin/FoMFilterModule.cs
@@ -21,7 +21,7 @@ public class FoMFilterModule : IFilterModule
         Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
         PropertyNameCaseInsensitive = true,
     };
-    private readonly bool isTarget;
+    private readonly bool isEnabled;
     private readonly bool exclude;
     private readonly FrozenDictionary<string, string> builtin;
     private readonly ConcurrentDictionary<string, (string en, string ja)> cache = [];
@@ -32,9 +32,9 @@ public class FoMFilterModule : IFilterModule
     public FoMFilterModule(IProcessInfoStore processInfo, IOptions<FoMOptions> options, ILogger<FoMFilterModule> logger)
     {
         _ = User32.GetWindowThreadProcessId(processInfo.MainWindowHandle, out var processId);
-        if (GetProcessPath(processId) is { } exePath && Path.GetFileName(exePath) == "FieldsOfMistria.exe")
+        if (options.Value.IsEnabledCorrect && GetProcessPath(processId) is { } exePath && Path.GetFileName(exePath) == "FieldsOfMistria.exe")
         {
-            this.isTarget = true;
+            this.isEnabled = true;
             var path = Path.Combine(Path.GetDirectoryName(exePath)!, "localization.json");
             using var fs = File.OpenRead(path);
             var loc = JsonSerializer.Deserialize<Localization>(fs, serializerOptions);
@@ -65,7 +65,7 @@ public class FoMFilterModule : IFilterModule
 
     public IAsyncEnumerable<TextRect> ExecutePreTranslate(IAsyncEnumerable<TextRect> texts)
     {
-        if (this.isTarget)
+        if (this.isEnabled)
         {
             return texts.Select(Correct).OfType<TextRect>();
         }
@@ -130,7 +130,7 @@ public record Localization(Dictionary<string, string> Eng, Dictionary<string, st
 [DisplayName("Fields of Mistria専用")]
 public class FoMOptions : IPluginParam
 {
-    [DisplayName("ゲームに含まれているリソースを利用した補正を利用するかどうか")]
+    [DisplayName("ゲームに含まれているリソースを利用した補正を利用する")]
     public bool IsEnabledCorrect { get; set; } = true;
 
     [DisplayName("プレイヤー名")]

--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -90,6 +90,8 @@ builder.Services.AddTransient(_ =>
     dlg.Resources.Remove(typeof(Button));
     dlg.SetCurrentValue(Window.WindowStyleProperty, WindowStyle.None);
     dlg.SetCurrentValue(Window.TitleProperty, string.Empty);
+    dlg.SetCurrentValue(FrameworkElement.WidthProperty, 600d);
+    dlg.SetCurrentValue(Window.SizeToContentProperty, SizeToContent.Height);
     var btnStyle = new Style(typeof(Button), (Style)Application.Current.FindResource(typeof(Button)));
     btnStyle.Setters.Add(new Setter(FrameworkElement.MinWidthProperty, 120d));
     btnStyle.Setters.Add(new Setter(Control.PaddingProperty, new Thickness(8)));

--- a/WindowTranslator/UpdateChecker.cs
+++ b/WindowTranslator/UpdateChecker.cs
@@ -272,7 +272,7 @@ interface IUpdateChecker
 
     event EventHandler? UpdateAvailable;
 
-    Task CheckAsync(CancellationToken token);
+    Task CheckAsync(CancellationToken token = default);
     void Update();
     void OpenChangelog();
 }


### PR DESCRIPTION
`FoMFilterModule.cs`:
- `isTarget` フィールドを `isEnabled` に変更
- コンストラクタに `IsEnabledCorrect` チェックを追加
- `ExecutePreTranslate` メソッドで `isEnabled` を使用
- `IsEnabledCorrect` プロパティの表示名を変更

`SettingsViewModel.cs`:
- `ObservableObject` を継承
- `hasUpdate` フィールドと `HasUpdate` プロパティを追加
- `UpdateInfo` プロパティが `HasUpdate` に依存
- `Checker_UpdateAvailable` メソッドを追加
- `CheckUpdateAsync` メソッドを追加
- `BeginEdit`、`CancelEdit`、`EndEdit` メソッドが `UpdateAvailable` イベントを管理

`Program.cs`:
- ダイアログの幅を 600 に設定、`SizeToContent` を `Height` に設定

`UpdateChecker.cs`:
- `CheckAsync` メソッドにデフォルト引数を追加