### PR TITLE
`SplitParagraph` メソッドの不要な `if` 文を削除

### DIFF
--- a/Plugins/WindowTranslator.Plugin.FoMPlugin/FoMFilterModule.cs
+++ b/Plugins/WindowTranslator.Plugin.FoMPlugin/FoMFilterModule.cs
@@ -79,10 +79,6 @@ public class FoMFilterModule : IFilterModule
 
     private static IEnumerable<(string en, string ja)> SplitParagraph(string en, string ja)
     {
-        if (string.IsNullOrEmpty(ja))
-        {
-            return [(en, ja)];
-        }
         var enLines = en.Split("\n\n", StringSplitOptions.RemoveEmptyEntries);
         var jaLines = ja.Split("\n\n", StringSplitOptions.RemoveEmptyEntries);
         if (enLines.Length == jaLines.Length)


### PR DESCRIPTION
`SplitParagraph` メソッド内で、`ja` が `null` または空文字列の場合に `(en, ja)` のタプルを返す処理を削除しました。これにより、`ja` が空の場合でも `en` と `ja` の段落を分割する処理が行われるようになります。