### PR TITLE
翻訳結果をキャッシュに追加する際に、元のテキストと翻訳されたテキストが異なる場合のみ追加するように変更しました。

### DIFF
--- a/Plugins/WindowTranslator.Plugin.DummyPlugin/DummyTranslator.cs
+++ b/Plugins/WindowTranslator.Plugin.DummyPlugin/DummyTranslator.cs
@@ -9,3 +9,10 @@ public class DummyTranslator : ITranslateModule
     public ValueTask<string[]> TranslateAsync(string[] srcTexts)
         => ValueTask.FromResult(srcTexts);
 }
+
+[DisplayName("空文字化")]
+public class TranslateEmptyModule : ITranslateModule
+{
+    public ValueTask<string[]> TranslateAsync(string[] srcTexts)
+        => ValueTask.FromResult((string[])Array.CreateInstance(typeof(string), srcTexts.Length));
+}

--- a/WindowTranslator/Modules/Main/MainViewModelBase.cs
+++ b/WindowTranslator/Modules/Main/MainViewModelBase.cs
@@ -150,7 +150,7 @@ public abstract partial class MainViewModelBase : IDisposable
             {
                 this.requesting.TryRemove(t, out _);
             }
-            this.cache.AddRange(transTargets.Zip(translated));
+            this.cache.AddRange(transTargets.Zip(translated).Where(p => p.First != p.Second));
         }
         catch (Exception e)
         {

--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -153,13 +153,6 @@ static string GetPluginName(PluginNameOptions options, Type type)
     }
 }
 
-[DisplayName("空文字化")]
-public class TranslateEmptyModule : ITranslateModule
-{
-    public ValueTask<string[]> TranslateAsync(string[] srcTexts)
-        => ValueTask.FromResult((string[])Array.CreateInstance(typeof(string), srcTexts.Length));
-}
-
 [DefaultModule]
 [DisplayName("翻訳しない")]
 public class NoTranslateModule : ITranslateModule


### PR DESCRIPTION
`Program.cs` から `TranslateEmptyModule` クラスを削除し、`DummyTranslator.cs` に移動しました。