### PR TITLE
用語集登録機能の追加と関連コードの修正

### DIFF
--- a/Plugins/WindowTranslator.Plugin.DeepLTranslatePlugin/DeepLTranslator.cs
+++ b/Plugins/WindowTranslator.Plugin.DeepLTranslatePlugin/DeepLTranslator.cs
@@ -3,32 +3,45 @@ using Microsoft.Extensions.Options;
 using PropertyTools.DataAnnotations;
 using System.Text.Json.Serialization;
 using WindowTranslator.Modules;
+using WindowTranslator.Stores;
 using DisplayNameAttribute = System.ComponentModel.DisplayNameAttribute;
 
 namespace WindowTranslator.Plugin.DeepLTranslatePlugin;
 
 [DisplayName("DeepL")]
-public class DeepLTranslator(IOptionsSnapshot<DeepLOptions> deeplOptions, IOptionsSnapshot<LanguageOptions> langOptions) : ITranslateModule
+public class DeepLTranslator(IProcessInfoStore processInfo, IOptionsSnapshot<DeepLOptions> deeplOptions, IOptionsSnapshot<LanguageOptions> langOptions) : ITranslateModule
 {
-    private readonly Translator translator = new(deeplOptions.Value.AuthKey, deeplOptions.Value.Options);
+    private readonly Translator translator = new(deeplOptions.Value.AuthKey);
     private readonly string sourceLang = langOptions.Value.Source[..2];
     private readonly string targetLang = langOptions.Value.Target switch
     {
         "en-US" or "en-GB" or "pt-BR" or "pt-PT" => langOptions.Value.Target,
         var t => t[..2],
     };
+    private readonly IProcessInfoStore processInfo = processInfo;
+    private readonly TextTranslateOptions translateOptions = new();
 
     public async ValueTask<string[]> TranslateAsync(string[] srcTexts)
     {
-        var translated = await translator.TranslateTextAsync(srcTexts, this.sourceLang, this.targetLang);
+        var translated = await translator.TranslateTextAsync(srcTexts, this.sourceLang, this.targetLang, this.translateOptions);
         return translated.Select(t => t.Text).ToArray();
+    }
+
+    public async ValueTask RegisterGlossaryAsync(IReadOnlyDictionary<string, string> glossary)
+    {
+        var list = await this.translator.ListGlossariesAsync().ConfigureAwait(false);
+        if (list.FirstOrDefault(g => g.Name == this.processInfo.Name) is { } exist)
+        {
+            await this.translator.DeleteGlossaryAsync(exist.GlossaryId).ConfigureAwait(false);
+        }
+        var created = await this.translator.CreateGlossaryAsync(this.processInfo.Name, this.sourceLang, this.targetLang, new(glossary, true)).ConfigureAwait(false);
+        this.translateOptions.GlossaryId = created.GlossaryId;
     }
 }
 
 public class DeepLOptions : IPluginParam
 {
     public string AuthKey { get; set; } = string.Empty;
-    public TranslatorOptions? Options { get; set; }
 
     [JsonIgnore]
     [Comment]

--- a/WindowTranslator.Abstractions/Modules/ITranslateModule.cs
+++ b/WindowTranslator.Abstractions/Modules/ITranslateModule.cs
@@ -11,4 +11,12 @@ public interface ITranslateModule
     /// <param name="srcTexts">翻訳するテキストの配列。</param>
     /// <returns>翻訳されたテキストの配列。</returns>
     ValueTask<string[]> TranslateAsync(string[] srcTexts);
+
+    /// <summary>
+    /// 翻訳モジュールに用語を登録します。
+    /// </summary>
+    /// <param name="glossary">用語</param>
+    /// <returns>非同期処理</returns>
+    ValueTask RegisterGlossaryAsync(IReadOnlyDictionary<string, string> glossary)
+        => default;
 }

--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -44,13 +44,13 @@ builder.Host.ConfigureLogging((c, l) => l.AddConfiguration(c.Configuration).AddS
 
 builder.Services.AddPluginFramework()
     .AddPluginCatalog(new AssemblyPluginCatalog(Assembly.GetExecutingAssembly(), new() { PluginNameOptions = { PluginNameGenerator = GetPluginName } }))
-    .AddPluginType<ITranslateModule>(configureDefault: op => op.DefaultType = GetPlugin<ITranslateModule>)
-    .AddPluginType<ICacheModule>(configureDefault: op => op.DefaultType = GetPlugin<ICacheModule>)
-    .AddPluginType<IOcrModule>(configureDefault: op => op.DefaultType = GetPlugin<IOcrModule>)
-    .AddPluginType<ICaptureModule>(configureDefault: op => op.DefaultType = GetPlugin<ICaptureModule>)
-    .AddPluginType<IColorModule>(configureDefault: op => op.DefaultType = GetPlugin<IColorModule>)
-    .AddPluginType<IPluginParam>()
-    .AddPluginType<IFilterModule>();
+    .AddPluginType<ITranslateModule>(ServiceLifetime.Scoped, op => op.DefaultType = GetPlugin<ITranslateModule>)
+    .AddPluginType<ICacheModule>(ServiceLifetime.Scoped, op => op.DefaultType = GetPlugin<ICacheModule>)
+    .AddPluginType<IOcrModule>(ServiceLifetime.Scoped, op => op.DefaultType = GetPlugin<IOcrModule>)
+    .AddPluginType<ICaptureModule>(ServiceLifetime.Scoped, op => op.DefaultType = GetPlugin<ICaptureModule>)
+    .AddPluginType<IColorModule>(ServiceLifetime.Scoped, op => op.DefaultType = GetPlugin<IColorModule>)
+    .AddPluginType<IFilterModule>(ServiceLifetime.Scoped)
+    .AddPluginType<IPluginParam>();
 
 var appPluginDir = @".\plugins";
 if (Directory.Exists(appPluginDir))


### PR DESCRIPTION
`DeepLTranslator.cs` では、`IProcessInfoStore` をコンストラクタに追加し、`TranslatorOptions` を削除して `TextTranslateOptions` を追加しました。また、`RegisterGlossaryAsync` メソッドを追加しました。

`FoMFilterModule.cs` では、`ITranslateModule` をコンストラクタに追加し、`builtin` の型を `FrozenDictionary<string, LocInto>` に変更しました。さらに、`RegisterGlossaryAsync` メソッドを呼び出す処理を追加し、`LocInto` 型を使用するように変更しました。`GlossaryRegex` メソッドを追加しました。

`ITranslateModule.cs` では、`RegisterGlossaryAsync` メソッドをインターフェースに追加しました。

`Program.cs` では、`AddPluginType` メソッドの呼び出しに `ServiceLifetime.Scoped` を追加しました。

Fix #130 