### PR TITLE
オーバーレイ切替機能の追加と設定の更新

### DIFF
--- a/WindowTranslator/Modules/Settings/SettingsViewModel.cs
+++ b/WindowTranslator/Modules/Settings/SettingsViewModel.cs
@@ -106,6 +106,9 @@ internal partial class SettingsViewModel : ObservableObject, IEditableObject
     public ViewMode ViewMode { get; set; }
 
     [Category("SettingsViewModel|Misc")]
+    public OverlaySwitch OverlaySwitch { get; set; }
+
+    [Category("SettingsViewModel|Misc")]
     public IList<ProcessName> AutoTargets { get; set; } = [];
 
     [Category("SettingsViewModel|Misc")]
@@ -163,6 +166,7 @@ internal partial class SettingsViewModel : ObservableObject, IEditableObject
         this.ViewMode = userSettings.Value.ViewMode;
         this.AutoTargets = userSettings.Value.AutoTargets.Select(t => new ProcessName() { Name = t }).ToList();
         this.IsEnableAutoTarget = userSettings.Value.IsEnableAutoTarget;
+        this.OverlaySwitch = userSettings.Value.OverlaySwitch;
 
         var asm = Assembly.GetExecutingAssembly();
         var name = asm.GetName();
@@ -279,6 +283,7 @@ internal partial class SettingsViewModel : ObservableObject, IEditableObject
             FontScale = this.FontScale,
             AutoTargets = this.AutoTargets.Select(t => t.Name).OfType<string>().ToList(),
             IsEnableAutoTarget = this.IsEnableAutoTarget,
+            OverlaySwitch = this.OverlaySwitch,
             SelectedPlugins =
             {
                 [nameof(ITranslateModule)] = this.TranslateModule,

--- a/WindowTranslator/Properties/Resources.Designer.cs
+++ b/WindowTranslator/Properties/Resources.Designer.cs
@@ -133,6 +133,15 @@ namespace WindowTranslator.Properties {
         }
         
         /// <summary>
+        ///   押している間だけ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Hold {
+            get {
+                return ResourceManager.GetString("Hold", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   メモリ内キャッシュ に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string InMemoryCache {
@@ -223,6 +232,15 @@ namespace WindowTranslator.Properties {
         }
         
         /// <summary>
+        ///   オーバーレイ表示の切り替え(Win+Alt+O) に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string OverlaySwitch {
+            get {
+                return ResourceManager.GetString("OverlaySwitch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   プラグイン設定 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Plugin {
@@ -282,6 +300,15 @@ namespace WindowTranslator.Properties {
         public static string Target {
             get {
                 return ResourceManager.GetString("Target", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   押してON/OFFを切り替える に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Toggle {
+            get {
+                return ResourceManager.GetString("Toggle", resourceCulture);
             }
         }
         

--- a/WindowTranslator/Properties/Resources.resx
+++ b/WindowTranslator/Properties/Resources.resx
@@ -207,4 +207,13 @@
   <data name="OpenChangelogCommand" xml:space="preserve">
     <value>詳細情報の確認</value>
   </data>
+  <data name="Hold" xml:space="preserve">
+    <value>押している間だけ</value>
+  </data>
+  <data name="Toggle" xml:space="preserve">
+    <value>押してON/OFFを切り替える</value>
+  </data>
+  <data name="OverlaySwitch" xml:space="preserve">
+    <value>オーバーレイ表示の切り替え(Win+Alt+O)</value>
+  </data>
 </root>

--- a/WindowTranslator/UserSettings.cs
+++ b/WindowTranslator/UserSettings.cs
@@ -1,4 +1,6 @@
-﻿using WindowTranslator.ComponentModel;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+using WindowTranslator.ComponentModel;
 using WindowTranslator.Properties;
 
 namespace WindowTranslator;
@@ -15,6 +17,8 @@ public class UserSettings
 
     public bool IsEnableAutoTarget { get; set; }
 
+    public OverlaySwitch OverlaySwitch { get; set; } = OverlaySwitch.Hold;
+
     public Dictionary<string, string> SelectedPlugins { get; init; } = new(StringComparer.OrdinalIgnoreCase);
 
     public Dictionary<string, IPluginParam> PluginParams { get; init; } = new(StringComparer.OrdinalIgnoreCase);
@@ -26,4 +30,12 @@ public enum ViewMode
     Capture,
     [LocalizedDescription(typeof(Resources), nameof(Overlay))]
     Overlay,
+}
+
+public enum OverlaySwitch
+{
+    [LocalizedDescription(typeof(Resources), nameof(Hold))]
+    Hold,
+    [LocalizedDescription(typeof(Resources), nameof(Toggle))]
+    Toggle,
 }


### PR DESCRIPTION
- `OverlayMainWindow.xaml.cs` に `Microsoft.Extensions.Options` のインポートを追加
- `OverlayMainWindow` クラスに `OverlaySwitch` フィールドを追加
- `OverlayMainWindow` のコンストラクタに `IOptionsSnapshot<UserSettings>` パラメータを追加し、`OverlaySwitch` フィールドを初期化
- `HideOverlay` メソッドを `HoldHideOverlay` に名前変更し、`OverlaySwitch` に基づく表示/非表示ロジックを追加
- `SettingsViewModel` クラスに `OverlaySwitch` プロパティを追加
- `SettingsViewModel` のコンストラクタと `Save` メソッドを変更し、`OverlaySwitch` プロパティを設定
- `Resources.Designer.cs` と `Resources.resx` に新しいローカライズ文字列 `Hold`, `OverlaySwitch`, `Toggle` を追加
- `UserSettings.cs` に `OverlaySwitch` プロパティと `OverlaySwitch` 列挙型を追加し、デフォルト値を `OverlaySwitch.Hold` に設定


Fix #135 