### PR TITLE
デバッグとリリースモードのディレクトリ設定の変更、およびプラグイン管理の改善。

### DIFF
--- a/WindowTranslator.Abstractions/PathUtility.cs
+++ b/WindowTranslator.Abstractions/PathUtility.cs
@@ -8,7 +8,11 @@ public static class PathUtility
     /// <summary>
     /// ユーザー設定ディレクトリのパスを取得します。
     /// </summary>
+#if DEBUG
+    public static readonly string UserDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".wt.debug");
+#else
     public static readonly string UserDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".wt");
+#endif
 
     /// <summary>
     /// ユーザー設定ファイルのパスを取得します。


### PR DESCRIPTION
#### PR Classification
デバッグとリリースモードのディレクトリ設定の変更、およびプラグイン管理の改善。

#### PR Summary
デバッグモードとリリースモードで異なるディレクトリを使用するように変更し、プラグイン管理機能を改善しました。
- `PathUtility.cs` でデバッグモードとリリースモードのディレクトリ設定を変更
- `Program.cs` に `Weikio.PluginFramework.AspNetCore` の using ステートメントを追加
- `Program.cs` で `GetPlugin` メソッドを `GetDefaultPlugin` に変更し、`GetPlugin` メソッドを削除
- `Program.cs` に `ServiceCollectionExtensions` クラスとその拡張メソッド `AddPluginType` を追加
