### PR TITLE
オーバーレイウィンドウのキャプチャ可能設定追加

### DIFF
--- a/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
+++ b/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
@@ -21,6 +21,7 @@ namespace WindowTranslator.Modules.Main;
 public partial class OverlayMainWindow : Window
 {
     private readonly OverlaySwitch overlaySwitch;
+    private readonly bool isEnableCapture;
     private readonly IProcessInfoStore processInfo;
     private readonly IPresentationService presentationService;
     private readonly DispatcherTimer timer = new();
@@ -52,6 +53,7 @@ public partial class OverlayMainWindow : Window
     {
         InitializeComponent();
         this.overlaySwitch = settings.Value.OverlaySwitch;
+        this.isEnableCapture = settings.Value.IsEnableCaptureOverlay;
         this.processInfo = processInfo;
         this.presentationService = presentationService;
         this.logger = logger;
@@ -68,8 +70,12 @@ public partial class OverlayMainWindow : Window
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
         this.windowHandle = new WindowInteropHelper(this).Handle;
-        var extendedStyle = (SetWindowLongFlags)GetWindowLong(windowHandle, WindowLongIndexFlags.GWL_EXSTYLE);
-        var r = SetWindowLong(windowHandle, WindowLongIndexFlags.GWL_EXSTYLE, extendedStyle | SetWindowLongFlags.WS_EX_TRANSPARENT | SetWindowLongFlags.WS_EX_TOOLWINDOW);
+        var extendedStyle = (SetWindowLongFlags)GetWindowLong(windowHandle, WindowLongIndexFlags.GWL_EXSTYLE) | SetWindowLongFlags.WS_EX_TRANSPARENT;
+        if (!this.isEnableCapture)
+        {
+            extendedStyle |= SetWindowLongFlags.WS_EX_TOOLWINDOW;
+        }
+        var r = SetWindowLong(windowHandle, WindowLongIndexFlags.GWL_EXSTYLE, extendedStyle);
         if (r == 0)
         {
             this.logger.LogError($"SetWindowLong failed. {Marshal.GetLastWin32Error()}");

--- a/WindowTranslator/Modules/Settings/SettingsViewModel.cs
+++ b/WindowTranslator/Modules/Settings/SettingsViewModel.cs
@@ -13,8 +13,6 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Unicode;
-using System.Windows.Markup;
-using System.Windows.Media;
 using Weikio.PluginFramework.Abstractions;
 using Weikio.PluginFramework.AspNetCore;
 using WindowTranslator.ComponentModel;
@@ -109,6 +107,9 @@ internal partial class SettingsViewModel : ObservableObject, IEditableObject
     public OverlaySwitch OverlaySwitch { get; set; }
 
     [Category("SettingsViewModel|Misc")]
+    public bool IsEnableCaptureOverlay { get; set; }
+
+    [Category("SettingsViewModel|Misc")]
     public IList<ProcessName> AutoTargets { get; set; } = [];
 
     [Category("SettingsViewModel|Misc")]
@@ -167,6 +168,7 @@ internal partial class SettingsViewModel : ObservableObject, IEditableObject
         this.AutoTargets = userSettings.Value.AutoTargets.Select(t => new ProcessName() { Name = t }).ToList();
         this.IsEnableAutoTarget = userSettings.Value.IsEnableAutoTarget;
         this.OverlaySwitch = userSettings.Value.OverlaySwitch;
+        this.IsEnableCaptureOverlay = userSettings.Value.IsEnableCaptureOverlay;
 
         var asm = Assembly.GetExecutingAssembly();
         var name = asm.GetName();
@@ -284,6 +286,7 @@ internal partial class SettingsViewModel : ObservableObject, IEditableObject
             AutoTargets = this.AutoTargets.Select(t => t.Name).OfType<string>().ToList(),
             IsEnableAutoTarget = this.IsEnableAutoTarget,
             OverlaySwitch = this.OverlaySwitch,
+            IsEnableCaptureOverlay = this.IsEnableCaptureOverlay,
             SelectedPlugins =
             {
                 [nameof(ITranslateModule)] = this.TranslateModule,

--- a/WindowTranslator/Properties/Resources.Designer.cs
+++ b/WindowTranslator/Properties/Resources.Designer.cs
@@ -160,6 +160,15 @@ namespace WindowTranslator.Properties {
         }
         
         /// <summary>
+        ///   オーバーレイ表示をキャプチャー可能にする に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string IsEnableCaptureOverlay {
+            get {
+                return ResourceManager.GetString("IsEnableCaptureOverlay", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   最新バージョンをご利用中です。 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string IsLatest {

--- a/WindowTranslator/Properties/Resources.resx
+++ b/WindowTranslator/Properties/Resources.resx
@@ -216,4 +216,7 @@
   <data name="OverlaySwitch" xml:space="preserve">
     <value>オーバーレイ表示の切り替え(Win+Alt+O)</value>
   </data>
+  <data name="IsEnableCaptureOverlay" xml:space="preserve">
+    <value>オーバーレイ表示をキャプチャー可能にする</value>
+  </data>
 </root>

--- a/WindowTranslator/Themes/DefaultStyles.xaml
+++ b/WindowTranslator/Themes/DefaultStyles.xaml
@@ -36,4 +36,8 @@
     <Style BasedOn="{StaticResource {x:Type RadioButton}}" TargetType="{x:Type RadioButton}">
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
+    <Style BasedOn="{StaticResource {x:Type pt:RadioButtonList}}" TargetType="{x:Type pt:RadioButtonList}">
+        <Setter Property="pt:RadioButtonList.ItemMargin" Value="0" />
+        <Setter Property="Margin" Value="0,4" />
+    </Style>
 </ResourceDictionary>

--- a/WindowTranslator/UserSettings.cs
+++ b/WindowTranslator/UserSettings.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Text.RegularExpressions;
-using WindowTranslator.ComponentModel;
+﻿using WindowTranslator.ComponentModel;
 using WindowTranslator.Properties;
 
 namespace WindowTranslator;
@@ -18,6 +16,8 @@ public class UserSettings
     public bool IsEnableAutoTarget { get; set; }
 
     public OverlaySwitch OverlaySwitch { get; set; } = OverlaySwitch.Hold;
+
+    public bool IsEnableCaptureOverlay { get; set; }
 
     public Dictionary<string, string> SelectedPlugins { get; init; } = new(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
- `OverlayMainWindow.xaml.cs` に `isEnableCapture` フィールドを追加
- `OverlayMainWindow` コンストラクタで `isEnableCapture` を初期化
- `Window_Loaded` メソッドで `isEnableCapture` が `false` の場合に `WS_EX_TOOLWINDOW` スタイルを追加
- `SettingsViewModel.cs` から不要な `using` ステートメントを削除
- `SettingsViewModel` クラスに `IsEnableCaptureOverlay` プロパティを追加
- `SettingsViewModel` コンストラクタで `IsEnableCaptureOverlay` を初期化
- `SettingsViewModel` の `Save` メソッドに `IsEnableCaptureOverlay` の保存を追加
- `Resources.Designer.cs` と `Resources.resx` に `IsEnableCaptureOverlay` のローカライズ文字列を追加
- `DefaultStyles.xaml` に `pt:RadioButtonList` のスタイルを追加
- `UserSettings.cs` から不要な `using` ステートメントを削除
- `UserSettings` クラスに `IsEnableCaptureOverlay` プロパティを追加


Fix #138 