### PR TITLE
言語をインストールする説明の改善

### DIFF
--- a/WindowTranslator/Modules/LanguagePackInstaller/LanguagePackInstallDialog.xaml
+++ b/WindowTranslator/Modules/LanguagePackInstaller/LanguagePackInstallDialog.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:WindowTranslator.Modules.LanguagePackInstaller"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:md="https://github.com/whistyun/MdXaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="LanguagePackInstallDialog"
     Width="320"
@@ -32,10 +33,73 @@
             Icon="{ui:ImageIcon '/wt.ico'}"
             ShowMaximize="False"
             ShowMinimize="False" />
-        <ui:TextBlock
+        <md:MarkdownScrollViewer
             x:Name="text"
             Margin="8"
-            TextWrapping="Wrap" />
+            ClickAction="OpenBrowser">
+            <md:MarkdownScrollViewer.MarkdownStyle>
+                <Style BasedOn="{x:Static md:MarkdownStyle.GithubLike}" TargetType="FlowDocument">
+                    <Style.Resources>
+                        <Style TargetType="Paragraph">
+                            <Setter Property="Margin" Value="0,8" />
+
+                            <Style.Triggers>
+                                <Trigger Property="Tag" Value="Heading1">
+                                    <Setter Property="Margin" Value="0,0,15,0" />
+
+                                    <Setter Property="Foreground" Value="{ui:ThemeResource TextFillColorSecondaryBrush}" />
+                                    <Setter Property="FontSize" Value="28" />
+                                    <Setter Property="FontWeight" Value="UltraBold" />
+                                </Trigger>
+
+                                <Trigger Property="Tag" Value="Heading2">
+                                    <Setter Property="Margin" Value="0,0,15,0" />
+
+                                    <Setter Property="Foreground" Value="{ui:ThemeResource TextFillColorSecondaryBrush}" />
+                                    <Setter Property="FontSize" Value="21" />
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                </Trigger>
+
+                                <Trigger Property="Tag" Value="Heading3">
+                                    <Setter Property="Margin" Value="0,0,10,0" />
+
+                                    <Setter Property="Foreground" Value="{ui:ThemeResource TextFillColorSecondaryBrush}" />
+                                    <Setter Property="FontSize" Value="17.5" />
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                </Trigger>
+
+                                <Trigger Property="Tag" Value="Heading4">
+                                    <Setter Property="Margin" Value="0,0,5,0" />
+
+                                    <Setter Property="Foreground" Value="{ui:ThemeResource TextFillColorSecondaryBrush}" />
+                                    <Setter Property="FontSize" Value="14" />
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                </Trigger>
+
+                                <Trigger Property="Tag" Value="CodeBlock">
+                                    <Setter Property="FontFamily" Value="Courier New" />
+                                    <Setter Property="FontSize" Value="11.9" />
+                                    <Setter Property="Background" Value="#12181F25" />
+                                    <Setter Property="Padding" Value="20,10" />
+                                </Trigger>
+
+                                <Trigger Property="Tag" Value="Note">
+                                    <Setter Property="Margin" Value="5,0,5,0" />
+                                    <Setter Property="Padding" Value="10,5" />
+                                    <Setter Property="BorderBrush" Value="#DEDEDE" />
+                                    <Setter Property="BorderThickness" Value="3,3,3,3" />
+                                    <Setter Property="Background" Value="#FAFAFA" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                        <Style TargetType="Hyperlink">
+                            <Setter Property="TextDecorations" Value="None" />
+                            <Setter Property="Foreground" Value="{ui:ThemeResource AccentTextFillColorSecondaryBrush}" />
+                        </Style>
+                    </Style.Resources>
+                </Style>
+            </md:MarkdownScrollViewer.MarkdownStyle>
+        </md:MarkdownScrollViewer>
         <ui:ProgressRing
             x:Name="progress"
             Width="48"

--- a/WindowTranslator/Modules/LanguagePackInstaller/LanguagePackInstallDialog.xaml.cs
+++ b/WindowTranslator/Modules/LanguagePackInstaller/LanguagePackInstallDialog.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Windows;
+using MdXaml;
 using Wpf.Ui.Controls;
 
 namespace WindowTranslator.Modules.LanguagePackInstaller;
@@ -16,10 +17,14 @@ public partial class LanguagePackInstallDialog : FluentWindow
         this.lang = lang;
         
         var culture = new CultureInfo(lang);
-        this.text.Text = $"""
+        this.text.Markdown = $"""
             翻訳元言語「{culture.DisplayName}」は文字認識のために必要なOCR機能がインストールされていません。
 
             インストールを行いますか？
+
+            > #### オプション
+            > [手動でインストールする](ms-settings:regionlanguage?activationSource=SMC-Article-14236) 
+            > ([手順](https://github.com/Freeesia/WindowTranslator/wiki/%E6%89%8B%E5%8B%95%E3%81%A7%E8%A8%80%E8%AA%9E%E3%83%91%E3%83%83%E3%82%AF%E3%82%92%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B))
             """;
     }
 
@@ -30,11 +35,15 @@ public partial class LanguagePackInstallDialog : FluentWindow
         button.Content = "インストール中...";
         this.progress.SetCurrentValue(VisibilityProperty, Visibility.Visible);
         var culture = new CultureInfo(lang);
-        this.text.SetCurrentValue(TextBlock.TextProperty, $"""
-            {culture.DisplayName} の言語パックをインストール中...
-            5,6分程度かかる場合があります。
+        this.text.SetCurrentValue(MarkdownScrollViewer.MarkdownProperty, $"""
+            「{culture.DisplayName}」の言語パックをインストール中...  
+            5～10分程度かかる場合があります。  
 
-            再起動が促された場合は再起動してください。
+            再起動が促された場合は再起動してください。  
+            
+            > #### オプション
+            > [手動でインストールする](ms-settings:regionlanguage?activationSource=SMC-Article-14236) 
+            > ([手順](https://github.com/Freeesia/WindowTranslator/wiki/%E6%89%8B%E5%8B%95%E3%81%A7%E8%A8%80%E8%AA%9E%E3%83%91%E3%83%83%E3%82%AF%E3%82%92%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B))
             """);
         try
         {

--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -164,7 +164,7 @@ public class ConfigurePluginParam<TOptions>(IConfiguration config) : IConfigureO
 
 static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddPluginType<T>(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Transient, Action<DefaultPluginOption> configureDefault = null) where T : class
+    public static IServiceCollection AddPluginType<T>(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Transient, Action<DefaultPluginOption>? configureDefault = null) where T : class
     {
         var item = new ServiceDescriptor(typeof(IEnumerable<T>), (IServiceProvider sp) => sp.GetRequiredService<PluginProvider>().GetTypes<T>().AsEnumerable(), serviceLifetime);
         var item2 = new ServiceDescriptor(typeof(T), delegate (IServiceProvider sp)

--- a/WindowTranslator/WindowTranslator.csproj
+++ b/WindowTranslator/WindowTranslator.csproj
@@ -34,6 +34,7 @@
     <!-- ↓8.3.0 に上げるとリリースでWinRT.Runtime.dllのバージョンが合わないみたいで起動できなくなる -->
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="ksemenenko.ColorThief" Version="1.1.1.4" />
+    <PackageReference Include="MdXaml" Version="1.27.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
`LanguagePackInstallDialog.xaml` に `MdXaml` 名前空間を追加し、`ui:TextBlock` を `md:MarkdownScrollViewer` に置き換えました。これにより、Markdown形式のテキスト表示が可能になりました。また、`LanguagePackInstallDialog.xaml.cs` ではテキストプロパティをMarkdownプロパティに変更しました。

`Program.cs` では、`AddPluginType` メソッドの `configureDefault` パラメータを `null` 許容型に変更し、柔軟な設定が可能になりました。

`WindowTranslator.csproj` に `MdXaml` パッケージバージョン `1.27.0` を追加しました。


Fix #137 