### PR TITLE
ホットキーの修飾キーを Win から Ctrl に変更

### DIFF
--- a/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
+++ b/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
@@ -89,7 +89,7 @@ public partial class OverlayMainWindow : Window
         SetWindowPos(hWndHiddenOwner, new(-1), 0, 0, 0, 0, SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOACTIVATE);
         this.timer.Start();
 
-        RegisterHotKey(new(this.windowHandle), 0, HOT_KEY_MODIFIERS.MOD_WIN | HOT_KEY_MODIFIERS.MOD_ALT, (uint)KeyInterop.VirtualKeyFromKey(Key.O));
+        RegisterHotKey(new(this.windowHandle), 0, HOT_KEY_MODIFIERS.MOD_CONTROL | HOT_KEY_MODIFIERS.MOD_ALT, (uint)KeyInterop.VirtualKeyFromKey(Key.O));
         var source = HwndSource.FromHwnd(this.windowHandle);
         source.AddHook(WndProc);
 

--- a/WindowTranslator/Properties/Resources.Designer.cs
+++ b/WindowTranslator/Properties/Resources.Designer.cs
@@ -241,7 +241,7 @@ namespace WindowTranslator.Properties {
         }
         
         /// <summary>
-        ///   オーバーレイ表示の切り替え(Win+Alt+O) に類似しているローカライズされた文字列を検索します。
+        ///   オーバーレイ表示の切り替え(Ctrl+Alt+O) に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string OverlaySwitch {
             get {

--- a/WindowTranslator/Properties/Resources.resx
+++ b/WindowTranslator/Properties/Resources.resx
@@ -214,7 +214,7 @@
     <value>押してON/OFFを切り替える</value>
   </data>
   <data name="OverlaySwitch" xml:space="preserve">
-    <value>オーバーレイ表示の切り替え(Win+Alt+O)</value>
+    <value>オーバーレイ表示の切り替え(Ctrl+Alt+O)</value>
   </data>
   <data name="IsEnableCaptureOverlay" xml:space="preserve">
     <value>オーバーレイ表示をキャプチャー可能にする</value>


### PR DESCRIPTION
`RegisterHotKey` メソッドの呼び出しにおいて、ホットキーの修飾キーが `HOT_KEY_MODIFIERS.MOD_WIN` から `HOT_KEY_MODIFIERS.MOD_CONTROL` に変更されました。これにより、ホットキーの組み合わせが `Win + Alt + O` から `Ctrl + Alt + O` に変更されました。

Fix #145 