### PR TITLE
対象ごとの設定の不具合修正

### DIFF
--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -150,7 +150,7 @@ class ConfigurePluginParam<TOptions>(IConfiguration configuration, IProcessInfoS
         var section = this.configuration.GetSection(name ?? this.store.Name);
         if (!section.Exists())
         {
-            section = this.configuration.GetSection(name ?? Options.DefaultName);
+            section = this.configuration.GetSection(Options.DefaultName);
         }
         section
             .GetSection(nameof(TargetSettings.PluginParams))


### PR DESCRIPTION
#### PR Classification
設定のリロード機能の追加とセクション取得方法の修正。

#### PR Summary
`AllSettingsViewModel` クラスに設定のリロード機能を追加し、`Program.cs` のセクション取得方法を修正しました。
- `AllSettingsViewModel.cs` に `Microsoft.Extensions.Configuration` を追加し、`IConfigurationRoot? rootConfig` フィールドを追加。
- `AllSettingsViewModel` のコンストラクタに `IConfiguration` パラメータを追加し、`rootConfig` を設定。
- `AllSettingsViewModel` の一部コードを `using` ステートメントで囲み、`rootConfig?.Reload()` メソッドを追加。
- `Program.cs` の `ConfigurePluginParam<TOptions>` クラス内でセクションの取得方法を修正。
