### PR TITLE
GoogleAIのプレビュー版を利用できるように

### DIFF
--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAIOptions.cs
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAIOptions.cs
@@ -13,6 +13,10 @@ public class GoogleAIOptions : IPluginParam
     [DisplayName("使用するモデル")]
     public GoogleAIModel Model { get; set; } = GoogleAIModel.Gemini15Flash;
 
+    [DisplayName("使用するプレビューモデル")]
+    [Description("モデル名を入力すると「使用するモデル」より優先されます")]
+    public string? PreviewModel { get; set; }
+
     [DisplayName("APIキー")]
     [DataType(DataType.Password)]
     public string? ApiKey { get; set; }

--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAITranslator.cs
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAITranslator.cs
@@ -30,12 +30,13 @@ public class GoogleAITranslator : ITranslateModule
         this.logger = logger;
         var src = CultureInfo.GetCultureInfo(langOptions.Value.Source).DisplayName;
         var target = CultureInfo.GetCultureInfo(langOptions.Value.Target).DisplayName;
+        var options = googleAiOptions.Value;
         this.preSystem = $$"""
         あなたは{{src}}から{{target}}へ翻訳するの専門家です。
         入力テキストは{{src}}のテキストであり、翻訳が必要です。
         渡されたテキストを{{target}}へ翻訳して出力してください。
         """;
-        this.userContext = googleAiOptions.Value.TranslateContext;
+        this.userContext = options.TranslateContext;
         this.postSystem = """
         入力テキストは以下のJsonフォーマットになっています。
         各textの内容はペアとなるcontextの文脈を考慮して翻訳してください。
@@ -50,7 +51,7 @@ public class GoogleAITranslator : ITranslateModule
         ["翻訳したテキスト1", "翻訳したテキスト2"]
         </出力テキストのJsonフォーマット>
         """;
-        if (googleAiOptions.Value.ApiKey is not { Length: > 0 } apiKey)
+        if (options.ApiKey is not { Length: > 0 } apiKey)
         {
             return;
         }
@@ -58,7 +59,7 @@ public class GoogleAITranslator : ITranslateModule
             apiKey,
             new()
             {
-                Model = googleAiOptions.Value.Model.GetName(),
+                Model = string.IsNullOrEmpty(options.PreviewModel) ? options.Model.GetName() : options.PreviewModel,
                 GenerationConfig = new GenerationConfigEx()
                 {
                     Temperature = 2.0,

--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAITranslator.cs
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAITranslator.cs
@@ -25,6 +25,8 @@ public class GoogleAITranslator : ITranslateModule
     private IReadOnlyList<string> common = [];
     private string? context;
 
+    public string Name => $"{nameof(GoogleAITranslator)}: {this.client?.Model ?? "Invalid"}";
+
     public GoogleAITranslator(IOptionsSnapshot<LanguageOptions> langOptions, IOptionsSnapshot<GoogleAIOptions> googleAiOptions, ILogger<GoogleAITranslator> logger)
     {
         this.logger = logger;

--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/OcrCorrectionFilter.cs
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/OcrCorrectionFilter.cs
@@ -17,6 +17,7 @@ public class OcrCorrectionFilter : IFilterModule
 
     public OcrCorrectionFilter(IOptionsSnapshot<LanguageOptions> langOptions, IOptionsSnapshot<GoogleAIOptions> googleAiOptions, ILogger<OcrCorrectionFilter> logger)
     {
+        var options = googleAiOptions.Value;
         var system = $"""
         あなたは{CultureInfo.GetCultureInfo(langOptions.Value.Source).DisplayName}の専門家です。
         これから渡される文字列はOCRによって認識されたものであり、誤字や脱字が含まれています。
@@ -29,7 +30,7 @@ public class OcrCorrectionFilter : IFilterModule
         5. 単語や文章として認識できない場合は、空文字を出力してください。
 
         <誤字修正の例>
-        {googleAiOptions.Value.CorrectSample}
+        {options.CorrectSample}
         </誤字修正の例>
 
         修正する文字列は以下のJsonフォーマットになっています。出力文字列も同じJsonフォーマットで、入力文字列の順序を維持してください。
@@ -45,13 +46,13 @@ public class OcrCorrectionFilter : IFilterModule
             SingleReader = true,
             SingleWriter = true,
         }, Dropped);
-        if (googleAiOptions.Value.IsEnabledCorrect && googleAiOptions.Value.ApiKey is { Length: > 0 } apiKey)
+        if (options.IsEnabledCorrect && options.ApiKey is { Length: > 0 } apiKey)
         {
             this.client = new(
                 apiKey,
                 new()
                 {
-                    Model = googleAiOptions.Value.Model.GetName(),
+                    Model = string.IsNullOrEmpty(options.PreviewModel) ? options.Model.GetName() : options.PreviewModel,
                     GenerationConfig = new GenerationConfigEx()
                     {
                         Temperature = 2.0,

--- a/WindowTranslator.Abstractions/Modules/ITranslateModule.cs
+++ b/WindowTranslator.Abstractions/Modules/ITranslateModule.cs
@@ -6,6 +6,11 @@
 public interface ITranslateModule
 {
     /// <summary>
+    /// モジュール名
+    /// </summary>
+    public string Name => GetType().Name;
+
+    /// <summary>
     /// 渡されたテキストを翻訳します。
     /// </summary>
     /// <param name="srcTexts">翻訳するテキストの配列。</param>

--- a/WindowTranslator/Modules/Main/MainViewModelBase.cs
+++ b/WindowTranslator/Modules/Main/MainViewModelBase.cs
@@ -77,7 +77,8 @@ public abstract partial class MainViewModelBase : IDisposable
         this.logger = logger;
         this.capture.StartCapture(processInfoStore.MainWindowHandle);
         this.timer = new(_ => CreateTextOverlayAsync().Forget(), null, 0, 500);
-        this.title = $"{this.name} - {this.translator.GetType().Name} ({Assembly.GetExecutingAssembly().GetName().Version})";
+        var transAsm = this.translator.GetType().Assembly;
+        this.title = $"{this.name} - {this.translator.Name} ({transAsm.GetName().Version})";
     }
 
     private async Task Capture_CapturedAsync(object? sender, CapturedEventArgs args)

--- a/WindowTranslator/Modules/Settings/AllSettingsDialog.xaml
+++ b/WindowTranslator/Modules/Settings/AllSettingsDialog.xaml
@@ -218,7 +218,11 @@
                             Margin="8"
                             ControlFactory="{StaticResource factory}"
                             Operator="{StaticResource operator}"
-                            SelectedObject="{Binding SelectedTarget}" />
+                            SelectedObject="{Binding SelectedTarget}">
+                            <pt:PropertyGrid.Resources>
+                                <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="{StaticResource TextFillColorDisabled}" />
+                            </pt:PropertyGrid.Resources>
+                        </pt:PropertyGrid>
                     </Grid>
                 </TabItem>
                 <TabItem Header="Abount">

--- a/WindowTranslator/Modules/Settings/SettingsPropertyGridFactory.cs
+++ b/WindowTranslator/Modules/Settings/SettingsPropertyGridFactory.cs
@@ -55,6 +55,58 @@ internal class SettingsPropertyGridFactory : PropertyGridControlFactory
         return comboBox;
     }
 
+    protected override FrameworkElement CreateDefaultControl(PropertyItem property)
+    {
+        var textBoxEx = new Wpf.Ui.Controls.TextBox
+        {
+            AcceptsReturn = property.AcceptsReturn,
+            MaxLength = property.MaxLength,
+            IsReadOnly = property.IsReadOnly,
+            TextWrapping = property.TextWrapping,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            VerticalContentAlignment = property.AcceptsReturn ? VerticalAlignment.Top : VerticalAlignment.Center,
+            PlaceholderText = property.Description,
+        };
+        if (property.FontFamily != null)
+        {
+            textBoxEx.FontFamily = new FontFamily(property.FontFamily);
+        }
+
+        if (!double.IsNaN(property.FontSize))
+        {
+            textBoxEx.FontSize = property.FontSize;
+        }
+
+        if (property.IsReadOnly)
+        {
+            textBoxEx.Foreground = Brushes.RoyalBlue;
+        }
+
+        var binding = property.CreateBinding(property.AutoUpdateText ? UpdateSourceTrigger.PropertyChanged : UpdateSourceTrigger.Default);
+        if (property.ActualPropertyType != typeof(string) && IsNullable(property.ActualPropertyType))
+        {
+            binding.TargetNullValue = string.Empty;
+        }
+
+        textBoxEx.SetBinding(TextBox.TextProperty, binding);
+        return textBoxEx;
+    }
+
+    private static bool IsNullable(Type type)
+    {
+        if (!type.IsValueType)
+        {
+            return true;
+        }
+
+        if (Nullable.GetUnderlyingType(type) != null)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     [ValueConversion(typeof(FontFamily), typeof(string))]
     private class FontFamilyDisplayNameConverter : IValueConverter
     {


### PR DESCRIPTION
#### PR Classification
新機能の追加とコードの可読性向上

#### PR Summary
`GoogleAIOptions` に `PreviewModel` プロパティを追加し、関連するクラスでの使用方法を変更しました。また、翻訳モジュールの名前を取得できるようにしました。
- `GoogleAIOptions.cs` に `PreviewModel` プロパティを追加
- `GoogleAITranslator.cs` に `Name` プロパティを追加し、`PreviewModel` の使用を実装
- `OcrCorrectionFilter.cs` で `PreviewModel` の使用を実装
- `ITranslateModule.cs` に `Name` プロパティを追加
- `MainViewModelBase.cs` でタイトル生成方法を変更
