### PR TITLE
パッケージバージョンの中央管理への移行

### DIFF
--- a/ColorThief/ColorThief.Bench/ColorThief.Bench.csproj
+++ b/ColorThief/ColorThief.Bench/ColorThief.Bench.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="ksemenenko.ColorThief" Version="1.1.1.4" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="ksemenenko.ColorThief" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ColorThief/ColorThief.Test/ColorThief.Test.csproj
+++ b/ColorThief/ColorThief.Test/ColorThief.Test.csproj
@@ -10,11 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="ksemenenko.ColorThief" Version="1.1.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="ksemenenko.ColorThief" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ColorThief/ColorThief/ColorThief.csproj
+++ b/ColorThief/ColorThief/ColorThief.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 
 </Project>

--- a/Composition.WindowsRuntimeHelpers/Composition.WindowsRuntimeHelpers.csproj
+++ b/Composition.WindowsRuntimeHelpers/Composition.WindowsRuntimeHelpers.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
+    <PackageReference Include="SharpDX.Direct3D11" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://github.com/Freeesia/WindowTranslator</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Freeesia/WindowTranslator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>WindowTranslator;OCR;Translation</PackageTags>    
+    <PackageTags>WindowTranslator;OCR;Translation</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugType>embedded</DebugType>
@@ -27,4 +27,5 @@
       <_Parameter2>$([System.DateTime]::UtcNow.ToString("o"))</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,11 +14,11 @@
     <PackageVersion Include="ksemenenko.ColorThief" Version="1.1.1.4" />
     <PackageVersion Include="MdXaml" Version="1.27.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.6" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
@@ -31,7 +31,7 @@
     <PackageVersion Include="PropertyTools" Version="3.1.0" />
     <PackageVersion Include="PropertyTools.Wpf" Version="3.1.0" />
     <PackageVersion Include="Quickenshtein" Version="1.5.1" />
-    <PackageVersion Include="Sentry.Extensions.Logging" Version="4.13.0" />
+    <PackageVersion Include="Sentry.Extensions.Logging" Version="5.0.0" />
     <PackageVersion Include="SharpDX.Direct3D11" Version="4.2.0" />
     <PackageVersion Include="System.Drawing.Common" Version="9.0.0" />
     <PackageVersion Include="System.Interactive" Version="6.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="ColorHelper" Version="1.8.1" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageVersion Include="ConsoleAppFramework" Version="5.3.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="DeepL.net" Version="1.11.0" />
+    <PackageVersion Include="Google_GenerativeAI" Version="1.0.2" />
+    <PackageVersion Include="Kamishibai.Hosting" Version="3.0.1" />
+    <PackageVersion Include="ksemenenko.ColorThief" Version="1.1.1.4" />
+    <PackageVersion Include="MdXaml" Version="1.27.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.6" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
+    <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
+    <PackageVersion Include="Octokit" Version="13.0.1" />
+    <PackageVersion Include="PInvoke.User32" Version="0.7.124" />
+    <PackageVersion Include="PropertyTools" Version="3.1.0" />
+    <PackageVersion Include="PropertyTools.Wpf" Version="3.1.0" />
+    <PackageVersion Include="Quickenshtein" Version="1.5.1" />
+    <PackageVersion Include="Sentry.Extensions.Logging" Version="4.13.0" />
+    <PackageVersion Include="SharpDX.Direct3D11" Version="4.2.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="9.0.0" />
+    <PackageVersion Include="System.Interactive" Version="6.0.1" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="Weikio.PluginFramework.AspNetCore" Version="1.5.1" />
+    <PackageVersion Include="WixSharp_wix4" Version="2.4.3" />
+    <PackageVersion Include="WPF-UI" Version="3.0.5" />
+    <PackageVersion Include="WPF-UI.Tray" Version="3.0.5" />
+    <PackageVersion Include="WpfAnalyzers" Version="4.1.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="OpenAI" Version="2.1.0" />
+  </ItemGroup>
+</Project>

--- a/Plugins/Directory.Build.props
+++ b/Plugins/Directory.Build.props
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Extensions.Options" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PropertyTools" Version="3.1.0" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" ExcludeAssets="runtime" />
+    <PackageReference Include="PropertyTools" ExcludeAssets="runtime" />
+    <PackageReference Include="System.Linq.Async" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/WindowTranslator.Plugin.DeepLTranslatePlugin/WindowTranslator.Plugin.DeepLTranslatePlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.DeepLTranslatePlugin/WindowTranslator.Plugin.DeepLTranslatePlugin.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="DeepL.net" Version="1.11.0" />
+    <PackageReference Include="DeepL.net" />
   </ItemGroup>
 
 </Project>

--- a/Plugins/WindowTranslator.Plugin.FoMPlugin/WindowTranslator.Plugin.FoMPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.FoMPlugin/WindowTranslator.Plugin.FoMPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="PInvoke.User32" Version="0.7.124" ExcludeAssets="runtime" />
-    <PackageReference Include="Quickenshtein" Version="1.5.1" />
+    <PackageReference Include="PInvoke.User32" ExcludeAssets="runtime" />
+    <PackageReference Include="Quickenshtein" />
   </ItemGroup>
 </Project>

--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/WindowTranslator.Plugin.GoogleAIPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/WindowTranslator.Plugin.GoogleAIPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Google_GenerativeAI" Version="1.0.2" />
+    <PackageReference Include="Google_GenerativeAI" />
   </ItemGroup>
 
 </Project>

--- a/Plugins/WindowTranslator.Plugin.LLMPlugin/WindowTranslator.Plugin.LLMPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.LLMPlugin/WindowTranslator.Plugin.LLMPlugin.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="OpenAI" Version="2.1.0" />
+    <PackageReference Include="OpenAI" />
   </ItemGroup>
 </Project>

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ConsoleAppFramework" Version="5.2.4">
+    <PackageReference Include="ConsoleAppFramework">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="DeepL.net" Version="1.11.0" />
-    <PackageReference Include="Google_GenerativeAI" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+    <PackageReference Include="DeepL.net" />
+    <PackageReference Include="Google_GenerativeAI" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WindowTranslator.Abstractions/WindowTranslator.Abstractions.csproj
+++ b/WindowTranslator.Abstractions/WindowTranslator.Abstractions.csproj
@@ -13,11 +13,11 @@
     <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/WindowTranslator.Wix/WindowTranslator.Wix.csproj
+++ b/WindowTranslator.Wix/WindowTranslator.Wix.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixSharp_wix4" Version="2.4.3" />
+    <PackageReference Include="WixSharp_wix4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WindowTranslator.sln
+++ b/WindowTranslator.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "!Solution Items", "!Solutio
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Composition.WindowsRuntimeHelpers", "Composition.WindowsRuntimeHelpers\Composition.WindowsRuntimeHelpers.csproj", "{F1A4F2BD-B093-44B4-9133-DA9F197CD052}"
@@ -134,9 +135,9 @@ Global
 		{A7E6289F-9FF6-43E9-904F-AEC929248BC2} = {0B1130E1-2666-4D0F-B69E-4C0A849C56E6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		RESX_AutoCreateNewLanguageFiles = True
-		RESX_ConfirmAddLanguageFile = True
-		RESX_NeutralResourcesLanguage = ja-JP
 		SolutionGuid = {8ED22421-F4EA-4FE3-BBF6-62DFCDD195CB}
+		RESX_NeutralResourcesLanguage = ja-JP
+		RESX_ConfirmAddLanguageFile = True
+		RESX_AutoCreateNewLanguageFiles = True
 	EndGlobalSection
 EndGlobal

--- a/WindowTranslator/WindowTranslator.csproj
+++ b/WindowTranslator/WindowTranslator.csproj
@@ -38,6 +38,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.PowerShell.SDK" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" />
     <PackageReference Include="Microsoft.Windows.CsWin32" >

--- a/WindowTranslator/WindowTranslator.csproj
+++ b/WindowTranslator/WindowTranslator.csproj
@@ -30,33 +30,33 @@
     <None Include="appsettings.json" CopyToOutputDirectory="Always" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ColorHelper" Version="1.8.1" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="ksemenenko.ColorThief" Version="1.1.1.4" />
-    <PackageReference Include="MdXaml" Version="1.27.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
+    <PackageReference Include="ColorHelper" />
+    <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="ksemenenko.ColorThief" />
+    <PackageReference Include="MdXaml" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.6" />
-    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
+    <PackageReference Include="Microsoft.PowerShell.SDK" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Octokit" Version="13.0.1" />
-    <PackageReference Include="PropertyTools.Wpf" Version="3.1.0" />
-    <PackageReference Include="Sentry.Extensions.Logging" Version="4.13.0" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="WPF-UI" Version="3.0.5" />
-    <PackageReference Include="WPF-UI.Tray" Version="3.0.5" />
-    <PackageReference Include="WpfAnalyzers" Version="4.1.1">
+    <PackageReference Include="Octokit" />
+    <PackageReference Include="PropertyTools.Wpf" />
+    <PackageReference Include="Sentry.Extensions.Logging" />
+    <PackageReference Include="System.Linq.Async" />
+    <PackageReference Include="WPF-UI" />
+    <PackageReference Include="WPF-UI.Tray" />
+    <PackageReference Include="WpfAnalyzers" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Kamishibai.Hosting" Version="3.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
-    <PackageReference Include="Weikio.PluginFramework.AspNetCore" Version="1.5.1" />
+    <PackageReference Include="Kamishibai.Hosting" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Weikio.PluginFramework.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/hwnd-adorner/HwndExtensions/HwndExtensions.csproj
+++ b/hwnd-adorner/HwndExtensions/HwndExtensions.csproj
@@ -4,8 +4,8 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
-    <PackageReference Include="PInvoke.User32" Version="0.7.124" />
-    <PackageReference Include="System.Interactive" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />
+    <PackageReference Include="PInvoke.User32" />
+    <PackageReference Include="System.Interactive" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
#### PR Classification
パッケージバージョンの中央管理への移行と関連するコードのクリーンアップ。

#### PR Summary
パッケージバージョンの指定を各プロジェクトファイルから削除し、中央管理に移行しました。また、いくつかのフォーマット修正を行いました。
- `Directory.Build.props` のフォーマット修正と閉じタグの追加
- `Directory.Packages.props` の新規追加によるパッケージバージョンの中央管理
- `WindowTranslator.sln` に `Directory.Packages.props` をソリューションアイテムとして追加
- 複数のプロジェクトファイルからパッケージバージョン指定を削除 (`ColorThief.csproj`, `WindowTranslator.csproj`, `Sandbox.csproj` など)
- `HwndExtensions.csproj` から複数のパッケージバージョン指定を削除
