### PR TITLE
json の初期化方法と条件付き修正を追加

### DIFF
--- a/Plugins/WindowTranslator.Plugin.LLMPlugin/LLMTranslator.cs
+++ b/Plugins/WindowTranslator.Plugin.LLMPlugin/LLMTranslator.cs
@@ -155,7 +155,15 @@ public class LLMTranslator : ITranslateModule
                 assitant,
             ], otherOptions)
             .ConfigureAwait(false);
-        var json = assitant.Content[0].Text + completion.Content[0].Text.Trim() + otherOptions.StopSequences[0];
+        var json = completion.Content[0].Text.Trim();
+        if (!json.StartsWith('{'))
+        {
+            json = assitant.Content[0].Text + json;
+        }
+        if (!json.EndsWith('}'))
+        {
+            json += otherOptions.StopSequences[0];
+        }
         var res = JsonSerializer.Deserialize<Response>(json, jsonOptions);
         return res?.Translated ?? [];
     }


### PR DESCRIPTION
json の初期化方法と条件付き修正を追加

`var json` の初期化方法を変更しました。以前は `assitant.Content[0].Text`、`completion.Content[0].Text.Trim()`、および `otherOptions.StopSequences[0]` を連結していましたが、変更後は `completion.Content[0].Text.Trim()` のみを使用しています。

また、`json` が `{` で始まらない場合に `assitant.Content[0].Text` を先頭に追加し、`json` が `}` で終わらない場合に `otherOptions.StopSequences[0]` を末尾に追加する条件を追加しました。