### PR TITLE
言語インストール確認メソッドの変更とパッケージ更新

### DIFF
--- a/WindowTranslator/Modules/Ocr/WindowsMediaOcrValidator.cs
+++ b/WindowTranslator/Modules/Ocr/WindowsMediaOcrValidator.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Globalization;
+﻿using System.Globalization;
 using Wpf.Ui;
 using Wpf.Ui.Controls;
 using Wpf.Ui.Extensions;
@@ -16,7 +15,7 @@ public class WindowsMediaOcrValidator(IContentDialogService dialogService) : ITa
         var culture = new CultureInfo(settings.Language.Source);
         try
         {
-            if (await WindowsMediaOcrUtility.IsInstalledLanguageAsync(settings.Language.Source))
+            if (WindowsMediaOcrUtility.IsInstalledLanguage(settings.Language.Source))
             {
                 return ValidateResult.Valid;
             }

--- a/WindowTranslator/WindowTranslator.csproj
+++ b/WindowTranslator/WindowTranslator.csproj
@@ -32,17 +32,15 @@
   <ItemGroup>
     <PackageReference Include="ColorHelper" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
-    <PackageReference Include="ksemenenko.ColorThief" />
     <PackageReference Include="MdXaml" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" >
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" >
+    <PackageReference Include="Microsoft.Windows.CsWin32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -52,7 +50,7 @@
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="WPF-UI" />
     <PackageReference Include="WPF-UI.Tray" />
-    <PackageReference Include="WpfAnalyzers" >
+    <PackageReference Include="WpfAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
言語インストール確認メソッドの変更とパッケージ更新

`WindowsMediaOcrUtility` と `WindowsMediaOcrValidator` において、言語のインストール確認方法を簡素化し、非同期処理を削除しました。また、プロジェクトファイル内のパッケージ参照を更新し、ビルド時の影響を制御する設定を追加しました。

Fix #277 