### PR TITLE
角丸の動的調整機能を追加

### DIFF
--- a/WindowTranslator/Data/SizeToCornerRadiusConverter.cs
+++ b/WindowTranslator/Data/SizeToCornerRadiusConverter.cs
@@ -1,0 +1,44 @@
+﻿using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace WindowTranslator.Data;
+
+[ValueConversion(typeof(FrameworkElement), typeof(double))]
+public sealed class SizeToCornerRadiusConverter : IValueConverter
+{
+    /// <summary>デフォルトインスタンスを取得</summary>
+    public static SizeToCornerRadiusConverter Default { get; } = new SizeToCornerRadiusConverter();
+
+    /// <summary>角丸の最大値</summary>
+    public double MaxValue { get; set; } = 10;
+
+    /// <summary>角丸の最小値</summary>
+    public double MinValue { get; set; } = 2;
+
+    /// <summary>比率感度を調整するためのスケール係数</summary>
+    public double ScaleFactor { get; set; } = 0.15;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not FrameworkElement element || double.IsNaN(element.MinWidth) || double.IsNaN(element.MinHeight))
+        {
+            return DependencyProperty.UnsetValue;
+        }
+
+        // 計算のために小さい方の寸法を使用
+        // TextRectの情報はMinWidthとMinHeightに格納されている
+        double smallerDimension = Math.Min(element.MinWidth, element.MinHeight);
+        
+        // スケール係数を使用して小さい方の寸法に基づいて半径を計算
+        double radius = smallerDimension * ScaleFactor;
+        
+        // 制約を適用
+        radius = Math.Max(MinValue, Math.Min(MaxValue, radius));
+        
+        return radius;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/WindowTranslator/Themes/Generic.xaml
+++ b/WindowTranslator/Themes/Generic.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary
+﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:control="clr-namespace:WindowTranslator.Controls"
@@ -17,6 +17,11 @@
                                 x:Key="b2dConv"
                                 FalseValue="0.5"
                                 TrueValue="1.0" />
+                            <data:SizeToCornerRadiusConverter
+                                x:Key="sizeToCornerRadiusConverter"
+                                MaxValue="10"
+                                MinValue="2"
+                                ScaleFactor="0.15" />
                         </ItemsControl.Resources>
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
@@ -28,11 +33,12 @@
                                 <Border
                                     MinWidth="{Binding Width}"
                                     MinHeight="{Binding Height}"
+                                    Padding="2"
                                     Background="{Binding Background, Converter={x:Static data:DrawingColorToBrushConverter.Default}}"
                                     BorderBrush="#40000000"
                                     BorderThickness="2"
                                     ClipToBounds="True"
-                                    CornerRadius="10"
+                                    CornerRadius="{Binding RelativeSource={RelativeSource Self}, Converter={StaticResource sizeToCornerRadiusConverter}}"
                                     Opacity="{Binding IsTranslated, Converter={StaticResource b2dConv}}">
                                     <Border.Resources>
                                         <data:BoolToDataTemplateConverter x:Key="b2dtConv">


### PR DESCRIPTION
角丸の動的調整機能を追加

`Generic.xaml` に新しい `SizeToCornerRadiusConverter` を追加し、要素のサイズに基づいて角丸の半径を動的に計算できるようにしました。この変更により、`TextRect` のサイズに応じた角丸の調整が可能になります。また、関連するクラス `SizeToCornerRadiusConverter` を実装し、計算に必要なプロパティを定義しました。

Fix #288