### PR TITLE
生成AI系翻訳モジュールのレスポンスのJson配列の最後の要素に「,」があっても正常にパースできるようにする

### DIFF
--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAITranslator.cs
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAITranslator.cs
@@ -16,7 +16,8 @@ public class GoogleAITranslator : ITranslateModule
 {
     private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
     {
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        AllowTrailingCommas = true,
     };
     private readonly string preSystem;
     private readonly string? userContext;

--- a/Plugins/WindowTranslator.Plugin.LLMPlugin/LLMTranslator.cs
+++ b/Plugins/WindowTranslator.Plugin.LLMPlugin/LLMTranslator.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Globalization;
-using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -19,7 +17,8 @@ public class LLMTranslator : ITranslateModule
 {
     private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
     {
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        AllowTrailingCommas = true,
     };
     private static readonly ChatCompletionOptions openAiOptions = new()
     {


### PR DESCRIPTION
生成AI系翻訳モジュールのレスポンスのJson配列の最後の要素に「,」があっても正常にパースできるようにする

`GoogleAITranslator.cs`および`LLMTranslator.cs`ファイルにおいて、名前空間の変更とJSONオプションの設定が更新されました。特に、`AllowTrailingCommas`プロパティが追加され、`using`ディレクティブの順序が整理されました。

Fix #299 