### PR TITLE
キャッシュ処理の条件を改善

### DIFF
--- a/WindowTranslator/Modules/Cache/InMemoryCache.cs
+++ b/WindowTranslator/Modules/Cache/InMemoryCache.cs
@@ -26,6 +26,13 @@ public class InMemoryCache(ILogger<InMemoryCache> logger, IOptionsSnapshot<Cache
         var (cacheSrc, dst, distance) = this.cache
             .Select(p => (src: p.Key, dst: p.Value, distance: Levenshtein.GetDistance(src, p.Key, CalculationOptions.DefaultWithThreading)))
             .MinBy(p => p.distance);
+
+        if (src.Length > cacheSrc.Length)
+        {
+            // 元の文字列がキャッシュより長い場合は、文字アニメで伸びているかもなので、キャッシュ対象外
+            return false;
+        }
+
         // 一致率の計算
         var p = 1 - ((float)distance / Math.Max(src.Length, cacheSrc.Length));
         this.logger.LogDebug($"LevenshteinDistance: {src} -> {cacheSrc} ({p:p2}%) [{DateTime.UtcNow - t}]");

--- a/WindowTranslator/Modules/Cache/LocalCache.cs
+++ b/WindowTranslator/Modules/Cache/LocalCache.cs
@@ -80,6 +80,13 @@ public sealed partial class LocalCache : ICacheModule, IDisposable
         var (cacheSrc, dst, distance) = this.cache
             .Select(p => (src: p.Key, dst: p.Value, distance: Levenshtein.GetDistance(src, p.Key, CalculationOptions.DefaultWithThreading)))
             .MinBy(p => p.distance);
+
+        if (src.Length > cacheSrc.Length)
+        {
+            // 元の文字列がキャッシュより長い場合は、文字アニメで伸びているかもなので、キャッシュ対象外
+            return false;
+        }
+
         // 一致率の計算
         var p = 1 - ((float)distance / Math.Max(src.Length, cacheSrc.Length));
         this.logger.LogDebug($"LevenshteinDistance: {src} -> {cacheSrc} ({p:p2}%) [{DateTime.UtcNow - t}]");


### PR DESCRIPTION
キャッシュ処理の条件を改善

`InMemoryCache` と `LocalCache` において、元の文字列がキャッシュされた文字列よりも長い場合にキャッシュ対象外とする条件を追加しました。これにより、文字アニメーションなどのケースを考慮したキャッシュ処理が実現されました。

Fix #366 