### PR TITLE
Gemini 2.5 Flash-Liteに対応

### DIFF
--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAIOptions.cs
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAIOptions.cs
@@ -44,6 +44,7 @@ public enum GoogleAIModel
     Gemini20Flash,
     Gemini25Flash,
     Gemini25Pro,
+    Gemini25FlashLite,
 }
 
 public enum CorrectMode
@@ -66,6 +67,7 @@ public static class GoogleAIModelExtensions
         GoogleAIModel.Gemini20Flash => GoogleAIModels.Gemini2Flash,
         GoogleAIModel.Gemini25Flash => "models/gemini-2.5-flash",
         GoogleAIModel.Gemini25Pro => "models/gemini-2.5-pro",
+        GoogleAIModel.Gemini25FlashLite => "models/gemini-2.5-flash-lite",
         _ => throw new ArgumentOutOfRangeException(nameof(model)),
     };
 }


### PR DESCRIPTION
GoogleAIModelに新しいモデルを追加

`GoogleAIModel` 列挙型に `Gemini25FlashLite` を追加し、関連するマッピングを `GoogleAIModelExtensions` クラスに実装しました。

Fix #412 