### PR TITLE
マウス位置のテキストのみオーバレイ翻訳を表示できるようにする

### DIFF
--- a/WindowTranslator.Abstractions/UserSettings.cs
+++ b/WindowTranslator.Abstractions/UserSettings.cs
@@ -37,6 +37,11 @@ public class CommonSettings
     public OverlaySwitch OverlaySwitch { get; set; } = OverlaySwitch.Hold;
 
     /// <summary>
+    /// オーバレイのポインター挙動を逆にするか
+    /// </summary>
+    public bool IsOverlayPointSwap { get; set; }
+
+    /// <summary>
     /// 自動的に翻訳を発動するか
     /// </summary>
     public bool IsEnableAutoTarget { get; set; }

--- a/WindowTranslator/Controls/OverlayTextsControl.cs
+++ b/WindowTranslator/Controls/OverlayTextsControl.cs
@@ -44,6 +44,16 @@ public class OverlayTextsControl : Control
     public static readonly DependencyProperty MousePosProperty =
         DependencyProperty.Register(nameof(MousePos), typeof(Point), typeof(OverlayTextsControl), new PropertyMetadata(new Point(double.NaN, double.NaN)));
 
+    public bool IsSwapVisibility
+    {
+        get => (bool)GetValue(IsSwapVisibilityProperty);
+        set => SetValue(IsSwapVisibilityProperty, value);
+    }
+
+    /// <summary>Identifies the <see cref="IsSwapVisibility"/> dependency property.</summary>
+    public static readonly DependencyProperty IsSwapVisibilityProperty =
+        DependencyProperty.Register(nameof(IsSwapVisibility), typeof(bool), typeof(OverlayTextsControl), new PropertyMetadata(false));
+
     public double Scale
     {
         get => (double)GetValue(ScaleProperty);

--- a/WindowTranslator/Data/TextOverlayVisibilityConverter.cs
+++ b/WindowTranslator/Data/TextOverlayVisibilityConverter.cs
@@ -11,12 +11,12 @@ public sealed class TextOverlayVisibilityConverter : IMultiValueConverter
 
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
-        if (values is not [TextRect rect, Point pos, double scale])
+        if (values is not [TextRect rect, Point pos, double scale, bool isSwap])
         {
             return Visibility.Visible;
         }
         var r = new Rect(rect.X * scale, rect.Y * scale, rect.Width * scale, rect.Height * scale);
-        return r.Contains(pos) ? Visibility.Collapsed : Visibility.Visible;
+        return r.Contains(pos) ^ isSwap ? Visibility.Collapsed : Visibility.Visible;
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/WindowTranslator/Modules/Main/OverlayMainWindow.xaml
+++ b/WindowTranslator/Modules/Main/OverlayMainWindow.xaml
@@ -29,6 +29,7 @@
         <control:OverlayTextsControl
             x:Name="overlay"
             FontFamily="{Binding Font, Mode=OneWay}"
+            IsSwapVisibility="{Binding IsSwapVisibility, ElementName=host, Mode=OneWay}"
             MousePos="{Binding MousePos, ElementName=host, Mode=OneWay}"
             RectHeight="{Binding Height}"
             RectWidth="{Binding Width}"

--- a/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
+++ b/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
@@ -10,6 +10,7 @@ using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 using Windows.Win32.UI.WindowsAndMessaging;
+using WindowTranslator.Controls;
 using WindowTranslator.Extensions;
 using WindowTranslator.Stores;
 using static Windows.Win32.PInvoke;
@@ -52,6 +53,16 @@ public partial class OverlayMainWindow : Window
     public static readonly DependencyProperty ScaleProperty =
         DependencyProperty.Register(nameof(Scale), typeof(double), typeof(OverlayMainWindow), new PropertyMetadata(1.0));
 
+    public bool IsSwapVisibility
+    {
+        get => (bool)GetValue(IsSwapVisibilityProperty);
+        set => SetValue(IsSwapVisibilityProperty, value);
+    }
+
+    /// <summary>Identifies the <see cref="IsSwapVisibility"/> dependency property.</summary>
+    public static readonly DependencyProperty IsSwapVisibilityProperty =
+        DependencyProperty.Register(nameof(IsSwapVisibility), typeof(bool), typeof(OverlayMainWindow), new PropertyMetadata(false));
+
     public OverlayMainWindow(
         IOptionsSnapshot<CommonSettings> settings,
         IOptionsSnapshot<TargetSettings> targetSettings,
@@ -62,6 +73,7 @@ public partial class OverlayMainWindow : Window
         InitializeComponent();
         this.overlaySwitch = settings.Value.OverlaySwitch;
         this.isEnableCapture = settings.Value.IsEnableCaptureOverlay;
+        this.IsSwapVisibility = settings.Value.IsOverlayPointSwap;
         this.processInfo = processInfo;
         this.desktopManager = desktopManager;
         this.logger = logger;

--- a/WindowTranslator/Modules/Settings/AllSettingsDialog.xaml
+++ b/WindowTranslator/Modules/Settings/AllSettingsDialog.xaml
@@ -206,7 +206,7 @@
                                 <CheckBox
                                     Grid.Row="3"
                                     Grid.Column="1"
-                                    Content="マウスポインター位置のテキストのみオーバレイ翻訳を表示する"
+                                    Content="{x:Static properties:Resources.IsOverlayPointSwap}"
                                     IsChecked="{Binding IsOverlayPointSwap}"
                                     IsEnabled="{Binding IsCheckableCapture}" />
                             </Grid>

--- a/WindowTranslator/Modules/Settings/AllSettingsDialog.xaml
+++ b/WindowTranslator/Modules/Settings/AllSettingsDialog.xaml
@@ -206,8 +206,9 @@
                                 <CheckBox
                                     Grid.Row="3"
                                     Grid.Column="1"
-                                    Content="処理中アイコンを表示する"
-                                    IsChecked="{Binding DisplayBusy}" />
+                                    Content="マウスポインター位置のテキストのみオーバレイ翻訳を表示する"
+                                    IsChecked="{Binding IsOverlayPointSwap}"
+                                    IsEnabled="{Binding IsCheckableCapture}" />
                             </Grid>
                         </GroupBox>
                         <GroupBox Header="{x:Static properties:Resources.AutoTargets}">

--- a/WindowTranslator/Modules/Settings/AllSettingsViewModel.cs
+++ b/WindowTranslator/Modules/Settings/AllSettingsViewModel.cs
@@ -75,6 +75,9 @@ sealed partial class AllSettingsViewModel : ObservableObject, IDisposable
     private OverlaySwitch overlaySwitch;
 
     [ObservableProperty]
+    private bool isOverlayPointSwap;
+
+    [ObservableProperty]
     private bool isEnableAutoTarget;
 
     [ObservableProperty]
@@ -116,6 +119,7 @@ sealed partial class AllSettingsViewModel : ObservableObject, IDisposable
         this.ViewMode = common.ViewMode;
         this.IsEnableCaptureOverlay = common.IsEnableCaptureOverlay;
         this.OverlaySwitch = common.OverlaySwitch;
+        this.IsOverlayPointSwap = common.IsOverlayPointSwap;
         this.IsEnableAutoTarget = common.IsEnableAutoTarget;
         this.AutoTargets = [.. autoTargetStore.AutoTargets];
 
@@ -222,6 +226,7 @@ sealed partial class AllSettingsViewModel : ObservableObject, IDisposable
                 ViewMode = this.ViewMode,
                 IsEnableAutoTarget = this.IsEnableAutoTarget,
                 OverlaySwitch = this.OverlaySwitch,
+                IsOverlayPointSwap = this.IsOverlayPointSwap,
                 IsEnableCaptureOverlay = this.IsEnableCaptureOverlay,
             },
             Targets = this.Targets.ToDictionary(t => t.Name, t => new TargetSettings()

--- a/WindowTranslator/Properties/Resources.Designer.cs
+++ b/WindowTranslator/Properties/Resources.Designer.cs
@@ -331,6 +331,15 @@ namespace WindowTranslator.Properties {
         }
         
         /// <summary>
+        ///   マウスポインター位置のテキストのみオーバレイ翻訳を表示する に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string IsOverlayPointSwap {
+            get {
+                return ResourceManager.GetString("IsOverlayPointSwap", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   言語設定 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Language {

--- a/WindowTranslator/Properties/Resources.de.resx
+++ b/WindowTranslator/Properties/Resources.de.resx
@@ -306,4 +306,7 @@
   <data name="DisplayBusy" xml:space="preserve">
     <value>Zeige das Beschäftigt-Symbol</value>
   </data>
+  <data name="IsOverlayPointSwap" xml:space="preserve">
+    <value>Overlay-Übersetzung nur für Text an der Mauszeiger-Position anzeigen</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.en.resx
+++ b/WindowTranslator/Properties/Resources.en.resx
@@ -306,4 +306,7 @@
   <data name="DisplayBusy" xml:space="preserve">
     <value>Show busy icon</value>
   </data>
+  <data name="IsOverlayPointSwap" xml:space="preserve">
+    <value>Display overlay translation only for text at mouse pointer position</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.ko.resx
+++ b/WindowTranslator/Properties/Resources.ko.resx
@@ -306,4 +306,7 @@
   <data name="DisplayBusy" xml:space="preserve">
     <value>처리 중 아이콘을 표시합니다</value>
   </data>
+  <data name="IsOverlayPointSwap" xml:space="preserve">
+    <value>마우스 포인터 위치의 텍스트에만 오버레이 번역을 표시</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.resx
+++ b/WindowTranslator/Properties/Resources.resx
@@ -306,4 +306,7 @@
   <data name="DisplayBusy" xml:space="preserve">
     <value>処理中アイコンを表示する</value>
   </data>
+  <data name="IsOverlayPointSwap" xml:space="preserve">
+    <value>マウスポインター位置のテキストのみオーバレイ翻訳を表示する</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.vi.resx
+++ b/WindowTranslator/Properties/Resources.vi.resx
@@ -271,16 +271,16 @@
     <value>Không dịch</value>
   </data>
   <data name="CacheParam" xml:space="preserve">
-    <value>キャッシュ設定</value>
+    <value>Cài đặt bộ nhớ đệm</value>
   </data>
   <data name="FuzzyMatchThreshold" xml:space="preserve">
-    <value>近いテキストの閾値</value>
+    <value>Ngưỡng văn bản gần</value>
   </data>
   <data name="NoCache" xml:space="preserve">
-    <value>キャッシュしない</value>
+    <value>Không lưu cache</value>
   </data>
   <data name="WindowsMediaOcr" xml:space="preserve">
-    <value>Windows標準文字認識</value>
+    <value>Nhận dạng ký tự chuẩn Windows</value>
   </data>
   <data name="Title" xml:space="preserve">
     <value>Tên ứng dụng</value>
@@ -305,5 +305,8 @@
   </data>
   <data name="DisplayBusy" xml:space="preserve">
     <value>Hiển thị biểu tượng bận</value>
+  </data>
+  <data name="IsOverlayPointSwap" xml:space="preserve">
+    <value>Chỉ hiển thị bản dịch lớp phủ cho văn bản tại vị trí con trỏ chuột</value>
   </data>
 </root>

--- a/WindowTranslator/Properties/Resources.zh-CN.resx
+++ b/WindowTranslator/Properties/Resources.zh-CN.resx
@@ -306,4 +306,7 @@
   <data name="DisplayBusy" xml:space="preserve">
     <value>显示忙碌图标</value>
   </data>
+  <data name="IsOverlayPointSwap" xml:space="preserve">
+    <value>仅在鼠标指针位置的文本上显示覆盖翻译</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.zh-TW.resx
+++ b/WindowTranslator/Properties/Resources.zh-TW.resx
@@ -306,4 +306,7 @@
   <data name="DisplayBusy" xml:space="preserve">
     <value>顯示忙碌圖標</value>
   </data>
+  <data name="IsOverlayPointSwap" xml:space="preserve">
+    <value>僅在滑鼠指標位置的文字上顯示重疊翻譯</value>
+  </data>
 </root>

--- a/WindowTranslator/Themes/Generic.xaml
+++ b/WindowTranslator/Themes/Generic.xaml
@@ -118,6 +118,7 @@
                                             <Binding Path="" />
                                             <Binding Path="MousePos" RelativeSource="{RelativeSource AncestorType=control:OverlayTextsControl}" />
                                             <Binding Path="Scale" RelativeSource="{RelativeSource AncestorType=control:OverlayTextsControl}" />
+                                            <Binding Path="IsSwapVisibility" RelativeSource="{RelativeSource AncestorType=control:OverlayTextsControl}" />
                                         </MultiBinding>
                                     </Setter.Value>
                                 </Setter>


### PR DESCRIPTION
Fix #422 