### PR TITLE
グローバルミューテックスの使用に変更

### DIFF
--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -33,7 +33,7 @@ using MessageBoxImage = Kamishibai.MessageBoxImage;
 #if DEBUG
 var createdNew = true;
 #else
-using var mutex = new Mutex(false, "WindowTranslator", out var createdNew);
+using var mutex = new Mutex(true, @"Global\WindowTranslator", out var createdNew);
 #endif
 if (!createdNew)
 {


### PR DESCRIPTION
グローバルミューテックスの使用に変更

アプリケーションの複数インスタンス実行を防ぐため、ミューテックスの作成方法を変更しました。これにより、グローバル名前空間でのロックが適用されるようになりました。

Fix #431