### PR TITLE
オーバーレイ位置修正

### DIFF
--- a/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
+++ b/WindowTranslator/Modules/Main/OverlayMainWindow.xaml.cs
@@ -192,7 +192,7 @@ public partial class OverlayMainWindow : Window
         GetWindowPlacement(new(this.processInfo.MainWindowHandle), ref p);
 
         var left = clientRect.left;
-        var top = p.showCmd.HasFlag(SHOW_WINDOW_CMD.SW_MAXIMIZE) ? clientRect.top : windowRect.top;
+        var top = p.showCmd.HasFlag(SHOW_WINDOW_CMD.SW_MAXIMIZE) ? monitorInfo.monitorInfo.rcWork.top : windowRect.top;
         var width = clientRect.right - left;
         var height = clientRect.bottom - top;
 

--- a/WindowTranslator/NativeMethods.txt
+++ b/WindowTranslator/NativeMethods.txt
@@ -38,3 +38,6 @@ GetWindowThreadProcessId
 // WindowMonitor
 EnumWindows
 IsWindowVisible
+
+// WindowsGraphicsCapture
+IsZoomed


### PR DESCRIPTION
WindowsGraphicsCaptureの改善とウィンドウ位置修正

`WindowsGraphicsCapture` クラスの初期化ロジックを整理し、ウィンドウの最大化状態を追跡する機能を追加しました。また、`OverlayMainWindow` でのウィンドウ位置取得の精度を向上させ、関連するメソッドのコメントを更新しました。

Fix #440 