### PR TITLE
「適用」ボタンでアタッチ中に変更を適用するとオーバーレイ切替機能が効かなくなる問題修正

### DIFF
--- a/WindowTranslator/Extensions/KamishibaiExtensions.cs
+++ b/WindowTranslator/Extensions/KamishibaiExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Kamishibai;
+
+namespace WindowTranslator.Extensions;
+public static class KamishibaiExtensions
+{
+    public static Task<bool> CloseAsync(this IWindow window)
+    {
+        var taskSource = new TaskCompletionSource<bool>();
+        var count = 0;
+        window.Closing += (_, e) =>
+        {
+            if (e.Cancel && count > 1)
+            {
+                taskSource.SetResult(false);
+            }
+            count++;
+        };
+        window.Closed += (_, _) =>
+        {
+            taskSource.SetResult(true);
+        };
+        window.Close();
+        return taskSource.Task;
+    }
+}

--- a/WindowTranslator/Modules/Settings/AllSettingsViewModel.cs
+++ b/WindowTranslator/Modules/Settings/AllSettingsViewModel.cs
@@ -308,7 +308,7 @@ sealed partial class AllSettingsViewModel : ObservableObject, IDisposable
         {
             foreach (var (_, handle, w) in this.mainWindowModule.OpenedWindows.Where(w => w.Name == target).ToArray())
             {
-                w.Close();
+                await w.CloseAsync();
                 await this.mainWindowModule.OpenTargetAsync(handle, target);
             }
         }


### PR DESCRIPTION
「適用」ボタンでアタッチ中に変更を適用するとオーバーレイ切替機能が効かなくなる問題修正