### PR TITLE
例外メッセージに詳細情報を追加

### DIFF
--- a/WindowTranslator/Modules/Ocr/WindowsMediaOcr.cs
+++ b/WindowTranslator/Modules/Ocr/WindowsMediaOcr.cs
@@ -42,7 +42,7 @@ public sealed partial class WindowsMediaOcr(
         var newHeight = (uint)(bitmap.PixelHeight * scale);
         if (newWidth > OcrEngine.MaxImageDimension || newHeight > OcrEngine.MaxImageDimension)
         {
-            throw new InvalidOperationException("ウィンドウサイズが大きすぎます。対象ウィンドウのサイズを小さくするか、認識設定の拡大率を下げてください。");
+            throw new InvalidOperationException($"ウィンドウサイズが大きすぎます。対象ウィンドウのサイズを小さくするか、認識設定の拡大率を下げてください。actual:({newWidth},{newHeight}), max:{OcrEngine.MaxImageDimension}");
         }
 
         // 拡大率に基づくリサイズ処理


### PR DESCRIPTION
例外メッセージに詳細情報を追加

ウィンドウサイズが大きすぎる場合の例外メッセージに、実際のサイズと最大サイズの情報を含めるよう変更しました。これにより、エラー発生時のデバッグが容易になります。