### PR TITLE
バージョンがパースできなかったときに文字列を例外に含める。

### DIFF
--- a/Plugins/WindowTranslator.Plugin.OneOcrPlugin/Utility.cs
+++ b/Plugins/WindowTranslator.Plugin.OneOcrPlugin/Utility.cs
@@ -74,7 +74,7 @@ static class Utility
         }
         if (!Version.TryParse(version, out var v))
         {
-            throw new InvalidOperationException($"Failed to parse ScreenSketch version. : {version}");
+            throw new InvalidOperationException($"Failed to parse {appName} version. : {version}");
         }
         return v;
     }


### PR DESCRIPTION
バージョンがパースできなかったときに文字列を例外に含める。