### PR TITLE
DependabotのPR作成上限を引き上げる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     reviewers:
       - "Freeesia"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     reviewers:
       - "Freeesia"


### PR DESCRIPTION
## 概要

Dependabotの各エコシステムで、同時に作成できるPR数を1件から5件へ引き上げます。

## 原因

既存のNuGet更新PR #574とGitHub Actions更新PR #613がCI失敗のまま残り、`open-pull-requests-limit: 1` に達していました。そのため、以後の更新ジョブが `Dependabot cannot open any more pull requests` で停止していました。

## 変更内容

- NuGetのPR作成上限を1件から5件へ変更
- GitHub ActionsのPR作成上限を1件から5件へ変更

これにより、特定の更新PRが停滞しても他の依存ライブラリ更新を継続できます。