### PR TITLE
null条件演算子を使用して簡潔に記述

### DIFF
--- a/WindowTranslator/Controls/NotifyIcon2.cs
+++ b/WindowTranslator/Controls/NotifyIcon2.cs
@@ -39,10 +39,7 @@ public class NotifyIcon2 : NotifyIcon, ICommandSource
 
     private void NotifyIcon2_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
-        if (this.Menu != null)
-        {
-            this.Menu.DataContext = this.DataContext;
-        }
+        this.Menu?.DataContext = this.DataContext;
     }
 
     protected override void OnMenuChanged(ContextMenu contextMenu)

--- a/WindowTranslator/Controls/WindowCaptureCompositionHost.cs
+++ b/WindowTranslator/Controls/WindowCaptureCompositionHost.cs
@@ -95,14 +95,8 @@ public class WindowCaptureCompositionHost : HwndExtensions.Host.HwndHostPresente
 
     private void OnCaptureModuleChanged(ICaptureModule? oldValue, ICaptureModule? newValue)
     {
-        if (oldValue is not null)
-        {
-            oldValue.Captured -= CaptureModule_CapturedAsync;
-        }
-        if (newValue is not null)
-        {
-            newValue.Captured += CaptureModule_CapturedAsync;
-        }
+        oldValue?.Captured -= CaptureModule_CapturedAsync;
+        newValue?.Captured += CaptureModule_CapturedAsync;
     }
 
     private Task CaptureModule_CapturedAsync(object? sender, CapturedEventArgs args)
@@ -142,10 +136,7 @@ public class WindowCaptureCompositionHost : HwndExtensions.Host.HwndHostPresente
                 {
                     InitComposition(hwndHost);
                 }
-                if (compositionTarget is not null)
-                {
-                    compositionTarget.Root = value;
-                }
+                compositionTarget?.Root = value;
             }
         }
 
@@ -156,8 +147,8 @@ public class WindowCaptureCompositionHost : HwndExtensions.Host.HwndHostPresente
                 0, 0,
                 hostWidth, hostHeight,
                 (HWND)hwndParent.Handle,
-                null!,
-                null!,
+                null,
+                null,
                 null);
 
             // ほかのコントローラをオーバーレイさせるためにキャプチャーは一番下のレイヤー扱い

--- a/hwnd-adorner/HwndExtensions/Host/HwndHostPresenter.cs
+++ b/hwnd-adorner/HwndExtensions/Host/HwndHostPresenter.cs
@@ -130,10 +130,7 @@ public class HwndHostPresenter : FrameworkElement, IDisposable
 
     protected override Size ArrangeOverride(Size arrangeSize)
     {
-        if (Child is not null)
-        {
-            Child.Arrange(new Rect(arrangeSize));
-        }
+        Child?.Arrange(new Rect(arrangeSize));
         return arrangeSize;
     }
 


### PR DESCRIPTION
手元でnullチェックをnull条件演算子に置き換えるリファクタリングを行いました。

## 変更内容

- `NotifyIcon2.cs`: `Menu` のnullチェックを `?.` 演算子に置き換え
- `WindowCaptureCompositionHost.cs`: イベントの購読・解除と `compositionTarget.Root` の代入をnull条件演算子に置き換え
- `HwndHostPresenter.cs`: `Child?.Arrange(...)` に簡潔化

## 確認事項

- ビルドは通っています
- 振る舞いに変更はありません