### PR TITLE
GitHub Copilot SDK 1.0.7 更新に伴う GitHubCopilotTranslator の修正

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="DeepL.net" Version="1.15.0" />
     <PackageVersion Include="Emoji.Wpf" Version="0.3.4" />
-    <PackageVersion Include="GitHub.Copilot.SDK" Version="0.2.0" />
+    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.7" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.75.0" />
     <PackageVersion Include="Google.Apis.Script.v1" Version="1.68.0.3294" />
     <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.15.0" />

--- a/Plugins/WindowTranslator.Plugin.GitHubCopilotPlugin/GitHubCopilotTranslator.cs
+++ b/Plugins/WindowTranslator.Plugin.GitHubCopilotPlugin/GitHubCopilotTranslator.cs
@@ -3,7 +3,8 @@ using System.Text;
 using System.Text.Json;
 using CsvHelper;
 using CsvHelper.Configuration;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
+using GitHub.Copilot.Rpc;
 using Microsoft.Extensions.Options;
 using ValueTaskSupplement;
 using WindowTranslator.Modules;
@@ -58,7 +59,7 @@ public class GitHubCopilotTranslator : ITranslateModule, IAsyncDisposable
         </出力テキストのJsonフォーマット>
         """;
 
-        this.client = new CopilotClient(new() { CliPath = Utility.GetBundledCliPath() });
+        this.client = new CopilotClient(new() { Connection = RuntimeConnection.ForStdio(Utility.GetBundledCliPath()) });
 
         this.session = new(this.CreateSessionAsync);
 
@@ -88,7 +89,9 @@ public class GitHubCopilotTranslator : ITranslateModule, IAsyncDisposable
                 Mode = SystemMessageMode.Replace,
                 Content = system,
             },
-            OnPermissionRequest = static (_, _) => Task.FromResult(new PermissionRequestResult() { Kind = PermissionRequestResultKind.NoResult }),
+#pragma warning disable GHCP001 // 種類は、評価の目的でのみ提供されています。将来の更新で変更または削除されることがあります。続行するには、この診断を非表示にします。
+            OnPermissionRequest = static (_, _) => Task.FromResult(PermissionDecision.UserNotAvailable()),
+#pragma warning restore GHCP001 // 種類は、評価の目的でのみ提供されています。将来の更新で変更または削除されることがあります。続行するには、この診断を非表示にします。
             ReasoningEffort = "low",
         }).ConfigureAwait(false);
         this.sessionStarted = true;
@@ -169,7 +172,7 @@ file static class CopilotClientExtensions
         var tcs = new TaskCompletionSource<AssistantMessageEvent?>(TaskCreationOptions.RunContinuationsAsynchronously);
         AssistantMessageEvent? lastAssistantMessage = null;
 
-        using var subscription = session.On(evt =>
+        using var subscription = session.On<SessionEvent>(evt =>
         {
             switch (evt)
             {
@@ -196,7 +199,7 @@ file static class CopilotClientExtensions
             }
         });
 
-        await session.SendAsync(new() { Prompt = prompt });
+        await session.SendAsync(new MessageOptions { Prompt = prompt });
 
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(effectiveTimeout);


### PR DESCRIPTION
## 概要
GitHub Copilot SDK を `0.2.0` から `1.0.7` へ更新したことに伴い、`WindowTranslator.Plugin.GitHubCopilotPlugin` の API 呼び出しを新 SDK に合わせて修正しました。

## 変更内容
- `Directory.Packages.props`
  - `GitHub.Copilot.SDK` のバージョンを `1.0.7` に更新
- `GitHubCopilotTranslator`
  - 名前空間を `GitHub.Copilot` ベースへ移行
  - `CopilotClient` 初期化を `CliPath` から `RuntimeConnection.ForStdio(...)` に変更
  - `session.On<SessionEvent>(...)` へ明示的に型指定
  - `SendAsync` の引数を `MessageOptions` に変更
  - `OnPermissionRequest` を SDK 1.0.7 の型に合わせて `PermissionDecision.UserNotAvailable()` を返すよう修正（該当警告を局所的に抑制）

## 動作確認
- `Plugins/WindowTranslator.Plugin.GitHubCopilotPlugin/WindowTranslator.Plugin.GitHubCopilotPlugin.csproj` のビルド成功を確認済み