### PR TITLE
二重起動時に既存のStartupDialogを表示する

### DIFF
--- a/WindowTranslator/Modules/Startup/StartupDialog.xaml.cs
+++ b/WindowTranslator/Modules/Startup/StartupDialog.xaml.cs
@@ -1,7 +1,13 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Interop;
+using Windows.Win32.Foundation;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
+using static Windows.Win32.PInvoke;
 
 namespace WindowTranslator.Modules.Startup;
 /// <summary>
@@ -9,13 +15,40 @@ namespace WindowTranslator.Modules.Startup;
 /// </summary>
 public partial class StartupDialog : FluentWindow
 {
+    private static readonly SafeFileHandle StartupDialogMarkerValue = new(new(1), ownsHandle: false);
     private readonly LaunchMode mode;
+    private HWND windowHandle;
+    private HwndSource? hwndSource;
+    private bool activationRequested;
 
     public StartupDialog(IConfiguration configuration)
     {
         SystemThemeWatcher.Watch(this);
         InitializeComponent();
         this.mode = configuration.GetValue(nameof(LaunchMode), LaunchMode.Direct);
+    }
+
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+        this.windowHandle = new(new WindowInteropHelper(this).Handle);
+        if (!SetProp(this.windowHandle, SingleInstanceWindowActivator.StartupDialogMarker, StartupDialogMarkerValue))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+        this.hwndSource = HwndSource.FromHwnd(this.windowHandle);
+        this.hwndSource.AddHook(WndProc);
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        this.hwndSource?.RemoveHook(WndProc);
+        if (!this.windowHandle.IsNull)
+        {
+            using SafeFileHandle marker = RemoveProp(this.windowHandle, SingleInstanceWindowActivator.StartupDialogMarker);
+            marker.SetHandleAsInvalid();
+        }
+        base.OnClosed(e);
     }
 
     private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
@@ -26,10 +59,39 @@ public partial class StartupDialog : FluentWindow
 
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
-        if (this.mode == LaunchMode.Startup)
+        if (this.activationRequested)
+        {
+            ActivateStartupDialog();
+        }
+        else if (this.mode == LaunchMode.Startup)
         {
             this.SetCurrentValue(VisibilityProperty, Visibility.Hidden);
         }
+    }
+
+    private IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        if (unchecked((uint)msg) == SingleInstanceWindowActivator.ActivationMessage)
+        {
+            this.activationRequested = true;
+            if (this.IsLoaded)
+            {
+                ActivateStartupDialog();
+            }
+            handled = true;
+        }
+        return IntPtr.Zero;
+    }
+
+    private void ActivateStartupDialog()
+    {
+        this.activationRequested = false;
+        Show();
+        if (this.WindowState == WindowState.Minimized)
+        {
+            this.SetCurrentValue(WindowStateProperty, WindowState.Normal);
+        }
+        _ = Activate();
     }
 }
 

--- a/WindowTranslator/NativeMethods.txt
+++ b/WindowTranslator/NativeMethods.txt
@@ -41,5 +41,15 @@ DwmGetWindowAttribute
 EnumWindows
 IsWindowVisible
 
+// SingleInstanceWindowActivator
+GetProp
+RegisterWindowMessage
+AllowSetForegroundWindow
+PostMessage
+
+// StartupDialog
+SetProp
+RemoveProp
+
 // WindowsGraphicsCapture
 IsZoomed

--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -33,24 +33,18 @@ using WindowTranslator.Modules.Validate;
 using WindowTranslator.Properties;
 using WindowTranslator.Stores;
 using Wpf.Ui;
-using MessageBoxImage = Kamishibai.MessageBoxImage;
 
 //Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo("it");
 //Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("it");
 
-#if DEBUG
+#if NO_MUTEX
 var createdNew = true;
 #else
 using var mutex = new Mutex(true, @"Global\WindowTranslator", out var createdNew);
 #endif
 if (!createdNew)
 {
-    new MessageDialog()
-    {
-        Caption = "WindowTranslator",
-        Icon = MessageBoxImage.Error,
-        Text = Resources.MutexError,
-    }.Show();
+    _ = SingleInstanceWindowActivator.TryActivateExistingInstance();
     return;
 }
 var d = SplashWindow.ShowSplash();

--- a/WindowTranslator/SingleInstanceWindowActivator.cs
+++ b/WindowTranslator/SingleInstanceWindowActivator.cs
@@ -1,0 +1,104 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
+using static Windows.Win32.PInvoke;
+
+namespace WindowTranslator;
+
+internal static class SingleInstanceWindowActivator
+{
+    private const string ActivationMessageName = "WindowTranslator.ActivateStartupDialog";
+    internal const string StartupDialogMarker = "WindowTranslator.StartupDialog";
+    internal static uint ActivationMessage { get; } = RegisterActivationMessage();
+
+    public static bool TryActivateExistingInstance()
+    {
+        HashSet<int> processIds = GetExistingInstanceProcessIds();
+        if (processIds.Count == 0)
+        {
+            return false;
+        }
+
+        HWND startupDialog = HWND.Null;
+        int startupProcessId = 0;
+        EnumWindows((hWnd, _) =>
+        {
+            if (GetWindowThreadProcessId(hWnd, out int processId) == 0 || !processIds.Contains(processId))
+            {
+                return true;
+            }
+
+            if (HasStartupDialogMarker(hWnd))
+            {
+                startupDialog = hWnd;
+                startupProcessId = processId;
+                return false;
+            }
+            return true;
+        }, IntPtr.Zero);
+
+        if (startupDialog.IsNull)
+        {
+            return false;
+        }
+
+        _ = AllowSetForegroundWindow(unchecked((uint)startupProcessId));
+        return PostMessage(startupDialog, ActivationMessage, default, default);
+    }
+
+    private static uint RegisterActivationMessage()
+    {
+        uint message = RegisterWindowMessage(ActivationMessageName);
+        return message != 0 ? message : throw new Win32Exception(Marshal.GetLastWin32Error());
+    }
+
+    private static bool HasStartupDialogMarker(HWND hWnd)
+    {
+        using SafeFileHandle marker = GetProp(hWnd, StartupDialogMarker);
+        bool hasMarker = !marker.IsInvalid;
+        marker.SetHandleAsInvalid();
+        return hasMarker;
+    }
+
+    private static HashSet<int> GetExistingInstanceProcessIds()
+    {
+        using Process currentProcess = Process.GetCurrentProcess();
+        HashSet<int> processIds = [];
+        foreach (Process process in Process.GetProcessesByName(currentProcess.ProcessName))
+        {
+            using (process)
+            {
+                if (process.Id != Environment.ProcessId && IsSameExecutable(process))
+                {
+                    processIds.Add(process.Id);
+                }
+            }
+        }
+        return processIds;
+    }
+
+    private static bool IsSameExecutable(Process process)
+    {
+        if (Environment.ProcessPath is not { } currentPath)
+        {
+            return true;
+        }
+
+        try
+        {
+            return string.Equals(process.MainModule?.FileName, currentPath, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Win32Exception)
+        {
+            // 同名プロセスの実行ファイルを参照できない環境でも、mutexの所有プロセスを候補から外さない。
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+}

--- a/WindowTranslator/WindowTranslator.csproj
+++ b/WindowTranslator/WindowTranslator.csproj
@@ -20,6 +20,9 @@
     <PublishReferencesDocumentationFiles>false</PublishReferencesDocumentationFiles>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineConstants>$(DefineConstants);NO_MUTEX</DefineConstants>
+  </PropertyGroup>
   <!-- Configure Sentry -->
   <PropertyGroup Condition="'$(SENTRY_AUTH_TOKEN)' != ''">
     <SentryOrg>studiofreesia</SentryOrg>


### PR DESCRIPTION
## 概要

起動時のmutexチェックで既存インスタンスを検出した場合、エラーダイアログを表示する代わりに、既存プロセスの`StartupDialog`を表示してアクティブ化します。

## 変更内容

- 同じ実行ファイルの既存プロセスを特定し、トップレベルウィンドウを列挙
- `SetProp`で付与したマーカーを使って`StartupDialog`のHWNDを特定
- 登録済みウィンドウメッセージを既存プロセスへ送り、WPFのUIスレッド上で`Show()`を実行
- 最小化されている場合は通常状態へ戻してから`Activate()`を実行
- `Loaded`前に復元要求を受信した場合も、読み込み完了後に表示
- 必要なWin32 API定義を`NativeMethods.txt`へ追加
- Debug構成では`NO_MUTEX`を定義し、複数プロセスでの確認を可能にする

## 背景

WPFの`Hide()`はネイティブの`WS_VISIBLE`だけでなく、WPF側の可視状態も変更します。そのため、2個目のプロセスから`ShowWindow`だけを呼ぶと、ウィンドウ枠は復元されてもWPFコンテンツが描画されない状態になります。

既存プロセスへ復元要求を通知し、そのプロセスのWPF UIスレッドで`Show()`を呼ぶことで、ウィンドウとコンテンツを正しく再表示します。

## 確認

- `dotnet build` 成功
- テストは依頼により未実施

Fixes #618