### PR TITLE
Issue #651 文字送り中の領域内Busyと最終文字列翻訳を実装

### DIFF
--- a/WindowTranslator.Abstractions/TextRect.cs
+++ b/WindowTranslator.Abstractions/TextRect.cs
@@ -33,6 +33,16 @@ public record TextRect(string SourceText, double X, double Y, double Width, doub
     public double MaxWidth { get; init; } = double.NaN;
 
     /// <summary>
+    /// 表示可能な翻訳結果を待っている理由。
+    /// </summary>
+    public TextRegionBusyReason BusyReasons { get; init; }
+
+    /// <summary>
+    /// 領域内にBusyを表示するかどうか。
+    /// </summary>
+    public bool IsBusy => this.BusyReasons != TextRegionBusyReason.None;
+
+    /// <summary>
     /// コンストラクタ
     /// </summary>
     /// <param name="text">テキスト</param>

--- a/WindowTranslator.Abstractions/TextRegionBusyReason.cs
+++ b/WindowTranslator.Abstractions/TextRegionBusyReason.cs
@@ -1,0 +1,23 @@
+namespace WindowTranslator;
+
+/// <summary>
+/// テキスト領域が表示可能な翻訳結果を待っている理由。
+/// </summary>
+[Flags]
+public enum TextRegionBusyReason
+{
+    /// <summary>
+    /// 待機していない。
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// 翻訳結果を待っている。
+    /// </summary>
+    Translation = 1 << 0,
+
+    /// <summary>
+    /// 文字送りの完了を待っている。
+    /// </summary>
+    Typewriter = 1 << 1,
+}

--- a/WindowTranslator.Tests/OcrTypewriterTrackingTests.cs
+++ b/WindowTranslator.Tests/OcrTypewriterTrackingTests.cs
@@ -1,0 +1,172 @@
+using System.Drawing;
+using Microsoft.Extensions.Logging.Abstractions;
+using WindowTranslator.Modules.Ocr;
+
+namespace WindowTranslator.Tests;
+
+public sealed class OcrTypewriterTrackingTests
+{
+    private static readonly Size imageSize = new(1280, 720);
+
+    [Fact]
+    public void ProgressiveTextStaysBusyAndOnlyTheFinalTextBecomesTranslatable()
+    {
+        OcrTextTracker tracker = CreateTracker();
+        List<string> translationRequests = [];
+
+        ObserveAndCollect(tracker, translationRequests, 0, Rect("H"));
+        TextRect he = ObserveAndCollect(tracker, translationRequests, 500, Rect("He")).Single();
+        TextRect hel = ObserveAndCollect(tracker, translationRequests, 1000, Rect("Hel")).Single();
+        TextRect helloBusy = ObserveAndCollect(tracker, translationRequests, 1500, Rect("Hello")).Single();
+        TextRect hello = ObserveAndCollect(tracker, translationRequests, 2000, Rect("Hello")).Single();
+
+        Assert.Equal(TextRegionBusyReason.Typewriter, he.BusyReasons);
+        Assert.Equal(TextRegionBusyReason.Typewriter, hel.BusyReasons);
+        Assert.Equal(TextRegionBusyReason.Typewriter, helloBusy.BusyReasons);
+        Assert.False(hello.IsBusy);
+        Assert.Equal("Hello", hello.SourceText);
+        Assert.Equal(["H", "Hello"], translationRequests);
+    }
+
+    [Fact]
+    public void OscillatingTailSelectsTheMostProgressedCandidateAndLeavesTypewriterBusy()
+    {
+        OcrTextTracker tracker = CreateTracker();
+        List<string> translationRequests = [];
+
+        ObserveAndCollect(tracker, translationRequests, 0, Rect("H"));
+        ObserveAndCollect(tracker, translationRequests, 500, Rect("He"));
+        ObserveAndCollect(tracker, translationRequests, 1000, Rect("Hel"));
+        ObserveAndCollect(tracker, translationRequests, 1500, Rect("Hello"));
+        ObserveAndCollect(tracker, translationRequests, 2000, Rect("Hell0"));
+        ObserveAndCollect(tracker, translationRequests, 2500, Rect("Hello"));
+        TextRect final = ObserveAndCollect(tracker, translationRequests, 3000, Rect("Hell0")).Single();
+
+        Assert.False(final.IsBusy);
+        Assert.Equal("Hello", final.SourceText);
+        Assert.Equal(["H", "Hello"], translationRequests);
+    }
+
+    [Fact]
+    public void ReturningToTheConfirmedTextCancelsTypewriterBusy()
+    {
+        OcrTextTracker tracker = CreateTracker();
+
+        TextRect original = Update(tracker, 0, Rect("Menu")).Single();
+        TextRect progressing = Update(tracker, 500, Rect("Menu...")).Single();
+        TextRect restored = Update(tracker, 1000, Rect("Menu")).Single();
+
+        Assert.False(original.IsBusy);
+        Assert.Equal(TextRegionBusyReason.Typewriter, progressing.BusyReasons);
+        Assert.False(restored.IsBusy);
+        Assert.Equal("Menu", restored.SourceText);
+    }
+
+    [Fact]
+    public void OrdinaryReplacementUsesTheExistingTextConfirmation()
+    {
+        OcrTextTracker tracker = CreateTracker();
+
+        Update(tracker, 0, Rect("Menu"));
+        TextRect candidate = Update(tracker, 500, Rect("Game")).Single();
+        TextRect confirmed = Update(tracker, 1000, Rect("Game")).Single();
+
+        Assert.False(candidate.IsBusy);
+        Assert.Equal("Menu", candidate.SourceText);
+        Assert.False(confirmed.IsBusy);
+        Assert.Equal("Game", confirmed.SourceText);
+    }
+
+    [Fact]
+    public void ProgressionCanStartAfterThePreviousTextWasReplaced()
+    {
+        OcrTextTracker tracker = CreateTracker();
+
+        Update(tracker, 0, Rect("Menu"));
+        TextRect firstCharacter = Update(tracker, 500, Rect("H")).Single();
+        TextRect progressing = Update(tracker, 1000, Rect("He")).Single();
+
+        Assert.False(firstCharacter.IsBusy);
+        Assert.Equal("Menu", firstCharacter.SourceText);
+        Assert.Equal(TextRegionBusyReason.Typewriter, progressing.BusyReasons);
+    }
+
+    [Fact]
+    public void ASingleExtensionAfterCompletionUsesTheExistingStabilization()
+    {
+        OcrTextTracker tracker = CreateTracker();
+
+        Update(tracker, 0, Rect("H"));
+        Update(tracker, 500, Rect("He"));
+        Update(tracker, 1000, Rect("Hello"));
+        TextRect completed = Update(tracker, 1500, Rect("Hello")).Single();
+        TextRect noise = Update(tracker, 2000, Rect("Hello!")).Single();
+
+        Assert.False(completed.IsBusy);
+        Assert.Equal("Hello", completed.SourceText);
+        Assert.False(noise.IsBusy);
+        Assert.Equal("Hello", noise.SourceText);
+    }
+
+    [Fact]
+    public void RapidRepeatedFramesDoNotEndTypewriterBeforeThePauseThreshold()
+    {
+        OcrTextTracker tracker = CreateTracker();
+
+        Update(tracker, 0, Rect("H"));
+        Update(tracker, 50, Rect("He"));
+        TextRect earlyRepeat = Update(tracker, 100, Rect("He")).Single();
+        TextRect stillProgressing = Update(tracker, 400, Rect("He")).Single();
+        TextRect completed = Update(tracker, 550, Rect("He")).Single();
+
+        Assert.True(earlyRepeat.IsBusy);
+        Assert.True(stillProgressing.IsBusy);
+        Assert.False(completed.IsBusy);
+        Assert.Equal("He", completed.SourceText);
+    }
+
+    [Fact]
+    public void ATypewriterTrackDoesNotBlockAnotherLogicalTrack()
+    {
+        OcrTextTracker tracker = CreateTracker();
+
+        Update(tracker, 0, Rect("H"), Rect("Status", x: 400));
+        IReadOnlyList<TextRect> output = Update(
+            tracker,
+            500,
+            Rect("He"),
+            Rect("Status", x: 400));
+
+        TextRect typewriter = Assert.Single(output, text => text.X == 100);
+        TextRect stable = Assert.Single(output, text => text.X == 400);
+        Assert.True(typewriter.IsBusy);
+        Assert.False(stable.IsBusy);
+        Assert.Equal("Status", stable.SourceText);
+    }
+
+    private static OcrTextTracker CreateTracker()
+        => new(NullLogger<OcrTextTracker>.Instance);
+
+    private static IReadOnlyList<TextRect> ObserveAndCollect(
+        OcrTextTracker tracker,
+        List<string> translationRequests,
+        int milliseconds,
+        params TextRect[] observations)
+    {
+        IReadOnlyList<TextRect> output = Update(tracker, milliseconds, observations);
+        translationRequests.AddRange(output
+            .Where(text => !text.IsBusy)
+            .Select(text => text.SourceText)
+            .Where(text => !translationRequests.Contains(text, StringComparer.Ordinal)));
+        return output;
+    }
+
+    private static IReadOnlyList<TextRect> Update(
+        OcrTextTracker tracker,
+        int milliseconds,
+        params TextRect[] observations)
+        => tracker.Update(observations, imageSize, TimeSpan.FromMilliseconds(milliseconds));
+
+    private static TextRect Rect(string text, double x = 100)
+        => new(text, x, 100, 160, 30, 20, false);
+}

--- a/WindowTranslator/Data/BoolToDataTemplateConverter.cs
+++ b/WindowTranslator/Data/BoolToDataTemplateConverter.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace WindowTranslator.Data;
+
+[ValueConversion(typeof(bool), typeof(DataTemplate))]
+public sealed class BoolToDataTemplateConverter : IValueConverter
+{
+    public required DataTemplate FalseContent { get; set; }
+
+    public required DataTemplate TrueContent { get; set; }
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is true ? this.TrueContent : this.FalseContent;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/WindowTranslator/Modules/Main/MainViewModelBase.cs
+++ b/WindowTranslator/Modules/Main/MainViewModelBase.cs
@@ -212,10 +212,19 @@ public abstract partial class MainViewModelBase : IDisposable
                 using var t = this.logger.LogDebugTime("PreTranslate");
                 texts = await tmp.ToArrayAsync();
             }
-            TranslateAsync(texts).Forget();
+            TranslateAsync(texts.Where(t => !t.IsBusy)).Forget();
             texts = texts.Select(t => t switch
             {
-                { TranslatedText: null } when this.cache.Contains(t.SourceText) => t with { TranslatedText = this.cache.Get(t.SourceText) },
+                { IsBusy: true } => t with { TranslatedText = null },
+                { TranslatedText: null } when this.cache.Contains(t.SourceText) => t with
+                {
+                    TranslatedText = this.cache.Get(t.SourceText),
+                    BusyReasons = t.BusyReasons & ~TextRegionBusyReason.Translation,
+                },
+                { TranslatedText: null } => t with
+                {
+                    BusyReasons = t.BusyReasons | TextRegionBusyReason.Translation,
+                },
                 _ => t,
             }).ToArray();
             {
@@ -260,6 +269,7 @@ public abstract partial class MainViewModelBase : IDisposable
                 return;
             }
             requests = requests
+                .Where(t => !t.IsBusy)
                 .Where(t => t.TranslatedText is null)
                 .Where(t => !this.cache.Contains(t.SourceText))
                 .ToArray();

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -23,6 +23,8 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
     private const double TextVoteDecay = 0.75;
     private const double TextVoteThreshold = 1.5;
     private const int TextVoteHistorySize = 5;
+    private const int TypewriterCandidateHistorySize = 7;
+    private const int TypewriterCooldownFrames = 2;
     private const double MinimumStructureSizeRatio = 0.65;
     private const double MinimumStructureOverlap = 0.45;
     private const double MinimumStructureTextSimilarity = 0.65;
@@ -31,6 +33,8 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
     private const double StrongOneToOneScore = 0.9;
     private const double AngleVectorEpsilon = 0.000000000001;
     private static readonly TimeSpan dormantRetention = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan typewriterStableDuration = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan typewriterTailDuration = TimeSpan.FromMilliseconds(1500);
 
     private readonly ILogger<OcrTextTracker> logger = logger;
     private readonly object syncRoot = new();
@@ -1622,6 +1626,8 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         private TextRect? geometryCandidate;
         private int geometryCandidateCount;
         private readonly List<TextVote> textVotes = [];
+        private TypewriterState? typewriter;
+        private int typewriterCooldownFrames;
         private string normalizedConfirmedText = NormalizeText(observation.SourceText);
         private DormantGeometry? dormantGeometry;
         private double velocityX;
@@ -1654,9 +1660,10 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         {
             this.MissedFrames = 0;
             this.UpdateMotion(current, timestamp);
+            string previousText = this.LatestObservation.SourceText;
             this.LatestObservation = current;
             this.LastObservationTime = timestamp;
-            this.UpdateText(current.SourceText);
+            this.UpdateText(previousText, current.SourceText, timestamp);
             this.UpdateGeometry(current);
             this.Stabilized = current with
             {
@@ -1668,6 +1675,9 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                 FontSize = this.Stabilized.FontSize,
                 MultiLine = this.Stabilized.MultiLine,
                 Angle = this.Stabilized.Angle,
+                BusyReasons = this.typewriter is null
+                    ? current.BusyReasons & ~TextRegionBusyReason.Typewriter
+                    : current.BusyReasons | TextRegionBusyReason.Typewriter,
             };
         }
 
@@ -1722,11 +1732,52 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             this.ResetMotion(timestamp);
         }
 
-        private void UpdateText(string current)
+        private void UpdateText(string previous, string current, TimeSpan timestamp)
         {
+            string normalizedPrevious = NormalizeText(previous);
             string normalizedCurrent = NormalizeText(current);
+
+            if (this.typewriter is not null)
+            {
+                if (normalizedCurrent == this.typewriter.Start.Normalized)
+                {
+                    this.typewriter = null;
+                    this.textVotes.Clear();
+                    return;
+                }
+
+                if (this.typewriter.Observe(new(normalizedCurrent, current), timestamp, out TextVote? final))
+                {
+                    TextVote confirmed = final
+                        ?? throw new InvalidOperationException("文字送りの最終候補がありません。");
+                    this.ConfirmedText = confirmed.Original;
+                    this.normalizedConfirmedText = confirmed.Normalized;
+                    this.typewriter = null;
+                    this.typewriterCooldownFrames = TypewriterCooldownFrames;
+                    this.textVotes.Clear();
+                }
+                return;
+            }
+
+            bool canStartTypewriter = this.typewriterCooldownFrames == 0;
+            if (this.typewriterCooldownFrames > 0)
+            {
+                this.typewriterCooldownFrames--;
+            }
+
             if (normalizedCurrent == this.normalizedConfirmedText)
             {
+                this.textVotes.Clear();
+                return;
+            }
+
+            if (canStartTypewriter && IsProgressiveTextChange(normalizedPrevious, normalizedCurrent))
+            {
+                this.typewriter = new(
+                    new(this.normalizedConfirmedText, this.ConfirmedText),
+                    new(normalizedPrevious, previous),
+                    new(normalizedCurrent, current),
+                    timestamp);
                 this.textVotes.Clear();
                 return;
             }
@@ -1764,6 +1815,11 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                 this.textVotes.Clear();
             }
         }
+
+        private static bool IsProgressiveTextChange(string previous, string current)
+            => previous.Length > 0
+                && current.Length > previous.Length
+                && current.StartsWith(previous, StringComparison.Ordinal);
 
         private void UpdateMotion(TextRect current, TimeSpan timestamp)
         {
@@ -1939,6 +1995,90 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                     Angle = NormalizeAngle(parent.Angle + this.AngleOffset),
                 };
             }
+        }
+
+        private sealed class TypewriterState(
+            TextVote start,
+            TextVote previous,
+            TextVote current,
+            TimeSpan timestamp)
+        {
+            private readonly List<TextVote> history = [previous, current];
+            private TextVote last = current;
+            private int consecutiveCount = 1;
+            private TimeSpan lastProgressTime = timestamp;
+
+            public TextVote Start { get; } = start;
+
+            public TextVote MostProgressed { get; private set; } = current;
+
+            public bool Observe(TextVote current, TimeSpan timestamp, out TextVote? final)
+            {
+                this.AddHistory(current);
+                if (current.Normalized == this.last.Normalized)
+                {
+                    this.consecutiveCount++;
+                }
+                else
+                {
+                    this.last = current;
+                    this.consecutiveCount = 1;
+                }
+
+                if (IsProgressiveTextChange(this.MostProgressed.Normalized, current.Normalized))
+                {
+                    this.MostProgressed = current;
+                    this.lastProgressTime = timestamp;
+                    final = null;
+                    return false;
+                }
+
+                if (current.Normalized == this.MostProgressed.Normalized
+                    && this.consecutiveCount >= 2)
+                {
+                    if (timestamp - this.lastProgressTime >= typewriterStableDuration)
+                    {
+                        final = current;
+                        return true;
+                    }
+                }
+
+                if (timestamp - this.lastProgressTime >= typewriterTailDuration)
+                {
+                    final = this.SelectFinal();
+                    return true;
+                }
+
+                final = null;
+                return false;
+            }
+
+            private void AddHistory(TextVote candidate)
+            {
+                this.history.Add(candidate);
+                if (this.history.Count > TypewriterCandidateHistorySize)
+                {
+                    this.history.RemoveAt(0);
+                }
+            }
+
+            private TextVote SelectFinal()
+                => this.history
+                    .Where(candidate => candidate.Normalized != this.Start.Normalized)
+                    .Select((candidate, index) => (candidate, index))
+                    .GroupBy(item => item.candidate.Normalized)
+                    .Select(group => new
+                    {
+                        Candidate = group.Last().candidate,
+                        Count = group.Count(),
+                        IsMostProgressed = group.Key == this.MostProgressed.Normalized,
+                        LastIndex = group.Max(item => item.index),
+                    })
+                    .OrderByDescending(candidate => candidate.Count)
+                    .ThenByDescending(candidate => candidate.IsMostProgressed)
+                    .ThenByDescending(candidate => candidate.LastIndex)
+                    .Select(candidate => candidate.Candidate)
+                    .FirstOrDefault(this.MostProgressed);
         }
 
         private sealed record TextVote(string Normalized, string Original);

--- a/WindowTranslator/Themes/Generic.xaml
+++ b/WindowTranslator/Themes/Generic.xaml
@@ -50,8 +50,8 @@
                                     CornerRadius="{Binding RelativeSource={RelativeSource Self}, Converter={StaticResource s2crConv}}"
                                     Opacity="{Binding TranslatedText, Converter={StaticResource n2dConv}}">
                                     <Border.Resources>
-                                        <data:NullToDataTemplateConverter x:Key="b2dtConv">
-                                            <data:NullToDataTemplateConverter.NotNullContent>
+                                        <data:BoolToDataTemplateConverter x:Key="b2dtConv">
+                                            <data:BoolToDataTemplateConverter.FalseContent>
                                                 <DataTemplate DataType="{x:Type root:TextRect}">
                                                     <TextBlock
                                                         Width="{Binding Converter={x:Static data:TextOverlayWidthConverter.Default}}"
@@ -65,8 +65,8 @@
                                                         </i:Interaction.Behaviors>
                                                     </TextBlock>
                                                 </DataTemplate>
-                                            </data:NullToDataTemplateConverter.NotNullContent>
-                                            <data:NullToDataTemplateConverter.NullContent>
+                                            </data:BoolToDataTemplateConverter.FalseContent>
+                                            <data:BoolToDataTemplateConverter.TrueContent>
                                                 <DataTemplate DataType="{x:Type root:TextRect}">
                                                     <Viewbox
                                                         Width="{Binding Width}"
@@ -97,15 +97,15 @@
                                                         </Path>
                                                     </Viewbox>
                                                 </DataTemplate>
-                                            </data:NullToDataTemplateConverter.NullContent>
-                                        </data:NullToDataTemplateConverter>
+                                            </data:BoolToDataTemplateConverter.TrueContent>
+                                        </data:BoolToDataTemplateConverter>
                                     </Border.Resources>
                                     <Border.RenderTransform>
                                         <TransformGroup>
                                             <RotateTransform Angle="{Binding Angle}" />
                                         </TransformGroup>
                                     </Border.RenderTransform>
-                                    <ContentControl Content="{Binding}" ContentTemplate="{Binding TranslatedText, Converter={StaticResource b2dtConv}}" />
+                                    <ContentControl Content="{Binding}" ContentTemplate="{Binding IsBusy, Converter={StaticResource b2dtConv}}" />
                                 </Border>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## 概要

Issue #651 に対応し、文字送り中は対象領域を Busy 表示に切り替え、途中の文字列を翻訳せず、終了後に選択した最終文字列だけを翻訳するようにしました。

## 変更内容

- 論理トラック単位の Busy 理由（翻訳待ち／文字送り待ち）を追加
- 同一トラックの文字列伸長を文字送りとして追跡
- 文字送り中は中間候補の翻訳要求と翻訳表示を抑制
- 末尾の OCR 揺れでは、進行度・候補履歴・反復観測から最終候補を確定
- 元の確定文字列へ戻った場合は文字送りを取り消し、以前の状態へ復帰
- 複数領域は独立して処理
- Busy 状態を明示的に UI へバインド

## 検証

- `dotnet build WindowTranslator.Tests\\WindowTranslator.Tests.csproj --no-restore -m:1 -nr:false -p:BuildInParallel=false -p:UseSharedCompilation=false`
- `dotnet test WindowTranslator.Tests\\WindowTranslator.Tests.csproj --no-build --no-restore -m:1 -nr:false -p:BuildInParallel=false -p:UseSharedCompilation=false`
- 全 67 件成功
- 既存の `LanguageOptions.cs` 警告（CS9336）以外のビルドエラーなし
- `git diff --check` 成功

Fixes #651