### PR TITLE
OCRトラッカーの複合分割・統合追跡を追加

### DIFF
--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -470,6 +470,35 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void ShiftedMergeWithNewRegionUsesCurrentNonOverlappingGeometry()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        tracker.Update(
+        [
+            new("Open", 40, 100, 40, 30, 24, false),
+            new("Menu", 85, 100, 55, 30, 24, false),
+        ],
+            imageSize,
+            TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> result = tracker.Update(
+        [
+            new("Open Menu", 0, 100, 90, 30, 24, false),
+            new("Settings", 100, 100, 80, 30, 24, false),
+        ],
+            imageSize,
+            TimeSpan.FromMilliseconds(500));
+
+        Assert.Equal(["Open", "Menu", "Settings"], result.Select(rect => rect.SourceText));
+        Assert.Equal((0, 36), (result[0].X, result[0].Width));
+        Assert.Equal(40.5, result[1].X, 5);
+        Assert.Equal(49.5, result[1].Width, 5);
+        Assert.Equal((100, 80), (result[2].X, result[2].Width));
+        Assert.True(result[1].X + result[1].Width <= result[2].X);
+    }
+
+    [Fact]
     public void ContinuouslyChangingTextEventuallyAdvancesToTheLatestObservation()
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);

--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -445,6 +445,31 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void ShiftedSplitWithFontSizeChangeAndNewRegionUsesCurrentNonOverlappingGeometry()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        tracker.Update(
+            [new("Open Menu", 40, 100, 100, 30, 24, false)],
+            imageSize,
+            TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> result = tracker.Update(
+        [
+            new("Open", 0, 100, 30, 20, 16, false),
+            new("Menu", 35, 100, 35, 20, 16, false),
+            new("Settings", 80, 100, 80, 20, 16, false),
+        ],
+            imageSize,
+            TimeSpan.FromMilliseconds(500));
+
+        Assert.Equal(["Open Menu", "Settings"], result.Select(rect => rect.SourceText));
+        Assert.Equal((0, 70, 20, 16), (result[0].X, result[0].Width, result[0].Height, result[0].FontSize));
+        Assert.Equal((80, 80), (result[1].X, result[1].Width));
+        Assert.True(result[0].X + result[0].Width <= result[1].X);
+    }
+
+    [Fact]
     public void ContinuouslyChangingTextEventuallyAdvancesToTheLatestObservation()
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);

--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -138,8 +138,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect initial = new("Menu", 300, 100, 100, 30, 24, false);
-        TextRect changed = new("Settings Menu", 250, 100, 200, 30, 24, false);
+        TextRect initial = new("Menu", 300, 100, 70, 30, 24, false);
+        TextRect changed = new("Settings Menu", 250, 100, 170, 30, 24, false);
         tracker.Update([initial], imageSize, TimeSpan.Zero);
 
         TextRect pending = Assert.Single(tracker.Update(
@@ -147,29 +147,26 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect confirmed = Assert.Single(tracker.Update(
             [changed], imageSize, TimeSpan.FromMilliseconds(1000)));
 
-        Assert.Equal(("Menu", 300, 100), (pending.SourceText, pending.X, pending.Width));
+        Assert.Equal(("Menu", 300, 70), (pending.SourceText, pending.X, pending.Width));
         Assert.Equal(
-            ("Settings Menu", 250, 200),
+            ("Settings Menu", 250, 170),
             (confirmed.SourceText, confirmed.X, confirmed.Width));
     }
 
     [Theory]
-    [InlineData(100, 100, 240, 60, true)]
-    [InlineData(100, 100, 240, 90, true)]
-    [InlineData(130, 100, 240, 90, true)]
-    [InlineData(100, 100, 180, 90, true)]
-    [InlineData(100, 100, 240, 90, false)]
-    [InlineData(100, 110, 240, 30, false)]
-    public void TextAndLayoutChangeWithMajorityOverlapStaysSingleAndConverges(
+    [InlineData(100, 100, 170, 60)]
+    [InlineData(110, 100, 170, 60)]
+    [InlineData(100, 100, 150, 60)]
+    [InlineData(100, 100, 120, 90)]
+    public void TextAndMultilineLayoutChangeWithMajorityOverlapStaysSingleAndConverges(
         double changedX,
         double changedY,
         double changedWidth,
-        double changedHeight,
-        bool changedMultiLine)
+        double changedHeight)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect initial = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect initial = new("Configure Menu", 100, 100, 170, 30, 24, false);
         TextRect changed = new(
             "Open Settings And Configure",
             changedX,
@@ -177,7 +174,7 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
             changedWidth,
             changedHeight,
             24,
-            changedMultiLine);
+            true);
         tracker.Update([initial], imageSize, TimeSpan.Zero);
 
         TextRect pending = Assert.Single(tracker.Update(
@@ -185,9 +182,9 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect confirmed = Assert.Single(tracker.Update(
             [changed], imageSize, TimeSpan.FromMilliseconds(1000)));
 
-        Assert.Equal(("Menu", 30, false), (pending.SourceText, pending.Height, pending.MultiLine));
+        Assert.Equal(("Configure Menu", 30, false), (pending.SourceText, pending.Height, pending.MultiLine));
         Assert.Equal(
-            ("Open Settings And Configure", changedX, changedY, changedWidth, changedHeight, changedMultiLine),
+            ("Open Settings And Configure", changedX, changedY, changedWidth, changedHeight, true),
             (confirmed.SourceText, confirmed.X, confirmed.Y, confirmed.Width, confirmed.Height, confirmed.MultiLine));
 
         Assert.Single(tracker.Update(
@@ -195,23 +192,21 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect restored = Assert.Single(tracker.Update(
             [initial], imageSize, TimeSpan.FromMilliseconds(2000)));
         Assert.Equal(
-            ("Menu", 30, false),
+            ("Configure Menu", 30, false),
             (restored.SourceText, restored.Height, restored.MultiLine));
     }
 
-    [Theory]
-    [InlineData(112)]
-    [InlineData(124)]
-    public void MinorityOverlapDoesNotReplaceNeighboringRegion(double neighboringY)
+    [Fact]
+    public void SlightlyOverlappingCurrentRegionsRemainSeparate()
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect initial = new("Menu", 100, 100, 240, 30, 24, false);
-        TextRect neighboring = new("Unrelated Panel", 100, neighboringY, 240, 30, 24, false);
-        tracker.Update([initial], imageSize, TimeSpan.Zero);
+        TextRect menu = new("Menu", 100, 100, 70, 30, 24, false);
+        TextRect neighboring = new("Unrelated Panel", 160, 124, 170, 30, 24, false);
+        tracker.Update([menu], imageSize, TimeSpan.Zero);
 
         IReadOnlyList<TextRect> result = tracker.Update(
-            [neighboring], imageSize, TimeSpan.FromMilliseconds(500));
+            [menu, neighboring], imageSize, TimeSpan.FromMilliseconds(500));
 
         Assert.Equal(["Menu", "Unrelated Panel"], result.Select(rect => rect.SourceText));
     }
@@ -221,8 +216,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect initial = new("Logo", 100, 100, 240, 60, 48, false);
-        TextRect changed = new("Caption", 100, 100, 240, 60, 24, false);
+        TextRect initial = new("Logo", 100, 100, 120, 58, 48, false);
+        TextRect changed = new("Long Caption", 95, 114, 130, 30, 24, false);
         tracker.Update([initial], imageSize, TimeSpan.Zero);
 
         TextRect pending = Assert.Single(tracker.Update(
@@ -231,7 +226,7 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
             [changed], imageSize, TimeSpan.FromMilliseconds(1000)));
 
         Assert.Equal(("Logo", 48), (pending.SourceText, pending.FontSize));
-        Assert.Equal(("Caption", 24), (confirmed.SourceText, confirmed.FontSize));
+        Assert.Equal(("Long Caption", 24), (confirmed.SourceText, confirmed.FontSize));
     }
 
     [Fact]
@@ -239,8 +234,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect logo = new("Logo", 100, 100, 240, 60, 48, false);
-        TextRect caption = new("Caption", 180, 125, 120, 24, 20, false);
+        TextRect logo = new("Logo", 100, 100, 120, 58, 48, false);
+        TextRect caption = new("Caption", 135, 120, 90, 24, 20, false);
 
         Assert.Equal(2, tracker.Update(
             [logo, caption], imageSize, TimeSpan.Zero).Count);
@@ -255,16 +250,16 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect initial = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect initial = new("Menu", 100, 100, 70, 30, 24, false);
         TextRect[] neighboring =
         [
-            new("Unrelated", 100, 112, 120, 30, 24, false),
-            new("Panel", 220, 112, 120, 30, 24, false),
+            new("Unrelated", 160, 124, 110, 30, 24, false),
+            new("Panel", 270, 124, 65, 30, 24, false),
         ];
         tracker.Update([initial], imageSize, TimeSpan.Zero);
 
         IReadOnlyList<TextRect> result = tracker.Update(
-            neighboring, imageSize, TimeSpan.FromMilliseconds(500));
+            [initial, .. neighboring], imageSize, TimeSpan.FromMilliseconds(500));
 
         Assert.Equal(["Menu", "Unrelated", "Panel"], result.Select(rect => rect.SourceText));
     }
@@ -274,11 +269,11 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect logo = new("Logo", 100, 100, 240, 60, 48, false);
+        TextRect logo = new("Logo", 100, 100, 120, 58, 48, false);
         TextRect[] overlay =
         [
-            new("Small", 140, 125, 80, 24, 20, false),
-            new("Caption", 220, 125, 80, 24, 20, false),
+            new("Small", 120, 120, 55, 24, 20, false),
+            new("Caption", 175, 120, 75, 24, 20, false),
         ];
         tracker.Update([logo], imageSize, TimeSpan.Zero);
 
@@ -295,10 +290,10 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         Size imageSize = new(1000, 600);
         TextRect[] fragments =
         [
-            new("Open", 100, 100, 90, 30, 24, false),
-            new("Menu", 200, 100, 140, 30, 24, false),
+            new("Open Options", 100, 100, 145, 30, 24, false),
+            new("And Configure", 245, 100, 155, 30, 24, false),
         ];
-        TextRect changedMerged = new("Settings Panel", 113, 100, 240, 30, 24, false);
+        TextRect changedMerged = new("Open Settings And Configure", 100, 100, 300, 30, 24, false);
         tracker.Update(fragments, imageSize, TimeSpan.Zero);
 
         IReadOnlyList<TextRect> pending = tracker.Update(
@@ -306,8 +301,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         IReadOnlyList<TextRect> recovered = tracker.Update(
             fragments, imageSize, TimeSpan.FromMilliseconds(1000));
 
-        Assert.Equal(["Open", "Menu"], pending.Select(rect => rect.SourceText));
-        Assert.Equal(["Open", "Menu"], recovered.Select(rect => rect.SourceText));
+        Assert.Equal(["Open Options", "And Configure"], pending.Select(rect => rect.SourceText));
+        Assert.Equal(["Open Options", "And Configure"], recovered.Select(rect => rect.SourceText));
     }
 
     [Fact]
@@ -315,11 +310,11 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect whole = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect whole = new("Open Options And Configure", 100, 100, 300, 30, 24, false);
         TextRect[] changedSplit =
         [
-            new("Open Settings", 113, 100, 150, 30, 24, false),
-            new("And Configure", 263, 100, 90, 30, 24, false),
+            new("Open Settings", 100, 100, 150, 30, 24, false),
+            new("And Configure", 250, 100, 150, 30, 24, false),
         ];
         tracker.Update([whole], imageSize, TimeSpan.Zero);
 
@@ -328,8 +323,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         IReadOnlyList<TextRect> recovered = tracker.Update(
             [whole], imageSize, TimeSpan.FromMilliseconds(1000));
 
-        Assert.Equal("Menu", Assert.Single(pending).SourceText);
-        Assert.Equal("Menu", Assert.Single(recovered).SourceText);
+        Assert.Equal("Open Options And Configure", Assert.Single(pending).SourceText);
+        Assert.Equal("Open Options And Configure", Assert.Single(recovered).SourceText);
     }
 
     [Fact]
@@ -337,11 +332,11 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect whole = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect whole = new("Open Options And Configure", 100, 100, 300, 30, 24, false);
         TextRect[] changedSplit =
         [
-            new("Open Settings", 113, 100, 150, 30, 24, false),
-            new("And Configure", 263, 100, 90, 30, 24, false),
+            new("Open Settings", 100, 100, 150, 30, 24, false),
+            new("And Configure", 250, 100, 150, 30, 24, false),
         ];
         tracker.Update([whole], imageSize, TimeSpan.Zero);
 
@@ -350,7 +345,7 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect confirmed = Assert.Single(tracker.Update(
             changedSplit, imageSize, TimeSpan.FromMilliseconds(1000)));
 
-        Assert.Equal("Menu", pending.SourceText);
+        Assert.Equal("Open Options And Configure", pending.SourceText);
         Assert.Equal("Open Settings And Configure", confirmed.SourceText);
     }
 
@@ -359,11 +354,11 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect whole = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect whole = new("Open Options And Configure", 100, 100, 300, 30, 24, false);
         TextRect[] changedSplit =
         [
-            new("Open Settings", 113, 100, 150, 30, 24, false),
-            new("And Configure", 263, 100, 90, 30, 24, false),
+            new("Open Settings", 100, 100, 150, 30, 24, false),
+            new("And Configure", 250, 100, 150, 30, 24, false),
         ];
         tracker.Update([whole], imageSize, TimeSpan.Zero);
         tracker.Update(changedSplit, imageSize, TimeSpan.FromMilliseconds(500));
@@ -375,7 +370,7 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect restored = Assert.Single(tracker.Update(
             [whole], imageSize, TimeSpan.FromMilliseconds(2000)));
 
-        Assert.Equal("Menu", restored.SourceText);
+        Assert.Equal("Open Options And Configure", restored.SourceText);
     }
 
     [Fact]
@@ -385,10 +380,10 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         Size imageSize = new(1000, 600);
         TextRect[] fragments =
         [
-            new("Open", 100, 100, 90, 30, 24, false),
-            new("Menu", 200, 100, 140, 30, 24, false),
+            new("Open Options", 100, 100, 145, 30, 24, false),
+            new("And Configure", 245, 100, 155, 30, 24, false),
         ];
-        TextRect changedMerged = new("Settings Panel", 113, 100, 240, 30, 24, false);
+        TextRect changedMerged = new("Open Settings And Configure", 100, 100, 300, 30, 24, false);
         tracker.Update(fragments, imageSize, TimeSpan.Zero);
 
         IReadOnlyList<TextRect> pending = tracker.Update(
@@ -396,8 +391,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect confirmed = Assert.Single(tracker.Update(
             [changedMerged], imageSize, TimeSpan.FromMilliseconds(1000)));
 
-        Assert.Equal(["Open", "Menu"], pending.Select(rect => rect.SourceText));
-        Assert.Equal("Settings Panel", confirmed.SourceText);
+        Assert.Equal(["Open Options", "And Configure"], pending.Select(rect => rect.SourceText));
+        Assert.Equal("Open Settings And Configure", confirmed.SourceText);
     }
 
     [Fact]
@@ -407,10 +402,10 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         Size imageSize = new(1000, 600);
         TextRect[] fragments =
         [
-            new("Open", 100, 100, 90, 30, 24, false),
-            new("Menu", 200, 100, 140, 30, 24, false),
+            new("Open Options", 100, 100, 145, 30, 24, false),
+            new("And Configure", 245, 100, 155, 30, 24, false),
         ];
-        TextRect changedMerged = new("Settings Panel", 113, 100, 240, 30, 24, false);
+        TextRect changedMerged = new("Open Settings And Configure", 100, 100, 300, 30, 24, false);
         tracker.Update(fragments, imageSize, TimeSpan.Zero);
         tracker.Update([changedMerged], imageSize, TimeSpan.FromMilliseconds(500));
         Assert.Single(tracker.Update(
@@ -421,7 +416,32 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         IReadOnlyList<TextRect> restored = tracker.Update(
             fragments, imageSize, TimeSpan.FromMilliseconds(2000));
 
-        Assert.Equal(["Open", "Menu"], restored.Select(rect => rect.SourceText));
+        Assert.Equal(["Open Options", "And Configure"], restored.Select(rect => rect.SourceText));
+    }
+
+    [Fact]
+    public void ShiftedSplitWithNewRegionUsesCurrentNonOverlappingGeometry()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        tracker.Update(
+            [new("Open Menu", 40, 100, 100, 30, 24, false)],
+            imageSize,
+            TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> result = tracker.Update(
+        [
+            new("Open", 0, 100, 40, 30, 24, false),
+            new("Menu", 45, 100, 45, 30, 24, false),
+            new("Settings", 100, 100, 80, 30, 24, false),
+        ],
+            imageSize,
+            TimeSpan.FromMilliseconds(500));
+
+        Assert.Equal(["Open Menu", "Settings"], result.Select(rect => rect.SourceText));
+        Assert.Equal((0, 90), (result[0].X, result[0].Width));
+        Assert.Equal((100, 80), (result[1].X, result[1].Width));
+        Assert.True(result[0].X + result[0].Width <= result[1].X);
     }
 
     [Fact]

--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -217,16 +217,35 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void LargeFontSizeDifferenceKeepsOverlappingRegionsSeparate()
+    public void SameRegionFontSizeChangeStaysSingleAndConverges()
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
         TextRect initial = new("Logo", 100, 100, 240, 60, 48, false);
-        TextRect overlay = new("Caption", 100, 100, 240, 60, 24, false);
+        TextRect changed = new("Caption", 100, 100, 240, 60, 24, false);
         tracker.Update([initial], imageSize, TimeSpan.Zero);
 
+        TextRect pending = Assert.Single(tracker.Update(
+            [changed], imageSize, TimeSpan.FromMilliseconds(500)));
+        TextRect confirmed = Assert.Single(tracker.Update(
+            [changed], imageSize, TimeSpan.FromMilliseconds(1000)));
+
+        Assert.Equal(("Logo", 48), (pending.SourceText, pending.FontSize));
+        Assert.Equal(("Caption", 24), (confirmed.SourceText, confirmed.FontSize));
+    }
+
+    [Fact]
+    public void DistinctSmallOverlayRemainsSeparateFromLargeRegion()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect logo = new("Logo", 100, 100, 240, 60, 48, false);
+        TextRect caption = new("Caption", 180, 125, 120, 24, 20, false);
+
+        Assert.Equal(2, tracker.Update(
+            [logo, caption], imageSize, TimeSpan.Zero).Count);
         IReadOnlyList<TextRect> result = tracker.Update(
-            [overlay], imageSize, TimeSpan.FromMilliseconds(500));
+            [logo, caption], imageSize, TimeSpan.FromMilliseconds(500));
 
         Assert.Equal(["Logo", "Caption"], result.Select(rect => rect.SourceText));
     }
@@ -251,20 +270,20 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void LargeFontSizeDifferenceDoesNotCreateCompositeStructureReplacement()
+    public void DistinctSmallOverlayFragmentsDoNotReplaceLargeRegion()
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
-        TextRect initial = new("Logo", 100, 100, 240, 60, 48, false);
+        TextRect logo = new("Logo", 100, 100, 240, 60, 48, false);
         TextRect[] overlay =
         [
-            new("Small", 100, 100, 120, 60, 24, false),
-            new("Caption", 220, 100, 120, 60, 24, false),
+            new("Small", 140, 125, 80, 24, 20, false),
+            new("Caption", 220, 125, 80, 24, 20, false),
         ];
-        tracker.Update([initial], imageSize, TimeSpan.Zero);
+        tracker.Update([logo], imageSize, TimeSpan.Zero);
 
         IReadOnlyList<TextRect> result = tracker.Update(
-            overlay, imageSize, TimeSpan.FromMilliseconds(500));
+            [logo, .. overlay], imageSize, TimeSpan.FromMilliseconds(500));
 
         Assert.Equal(["Logo", "Small", "Caption"], result.Select(rect => rect.SourceText));
     }
@@ -279,7 +298,7 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
             new("Open", 100, 100, 90, 30, 24, false),
             new("Menu", 200, 100, 140, 30, 24, false),
         ];
-        TextRect changedMerged = new("Settings Panel", 100, 100, 240, 30, 24, false);
+        TextRect changedMerged = new("Settings Panel", 113, 100, 240, 30, 24, false);
         tracker.Update(fragments, imageSize, TimeSpan.Zero);
 
         IReadOnlyList<TextRect> pending = tracker.Update(
@@ -299,8 +318,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect whole = new("Menu", 100, 100, 240, 30, 24, false);
         TextRect[] changedSplit =
         [
-            new("Open Settings", 100, 100, 150, 30, 24, false),
-            new("And Configure", 250, 100, 90, 30, 24, false),
+            new("Open Settings", 113, 100, 150, 30, 24, false),
+            new("And Configure", 263, 100, 90, 30, 24, false),
         ];
         tracker.Update([whole], imageSize, TimeSpan.Zero);
 
@@ -321,8 +340,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect whole = new("Menu", 100, 100, 240, 30, 24, false);
         TextRect[] changedSplit =
         [
-            new("Open Settings", 112, 100, 150, 30, 24, false),
-            new("And Configure", 262, 100, 90, 30, 24, false),
+            new("Open Settings", 113, 100, 150, 30, 24, false),
+            new("And Configure", 263, 100, 90, 30, 24, false),
         ];
         tracker.Update([whole], imageSize, TimeSpan.Zero);
 
@@ -343,8 +362,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect whole = new("Menu", 100, 100, 240, 30, 24, false);
         TextRect[] changedSplit =
         [
-            new("Open Settings", 112, 100, 150, 30, 24, false),
-            new("And Configure", 262, 100, 90, 30, 24, false),
+            new("Open Settings", 113, 100, 150, 30, 24, false),
+            new("And Configure", 263, 100, 90, 30, 24, false),
         ];
         tracker.Update([whole], imageSize, TimeSpan.Zero);
         tracker.Update(changedSplit, imageSize, TimeSpan.FromMilliseconds(500));
@@ -369,7 +388,7 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
             new("Open", 100, 100, 90, 30, 24, false),
             new("Menu", 200, 100, 140, 30, 24, false),
         ];
-        TextRect changedMerged = new("Settings Panel", 100, 100, 240, 30, 24, false);
+        TextRect changedMerged = new("Settings Panel", 113, 100, 240, 30, 24, false);
         tracker.Update(fragments, imageSize, TimeSpan.Zero);
 
         IReadOnlyList<TextRect> pending = tracker.Update(
@@ -391,7 +410,7 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
             new("Open", 100, 100, 90, 30, 24, false),
             new("Menu", 200, 100, 140, 30, 24, false),
         ];
-        TextRect changedMerged = new("Settings Panel", 100, 100, 240, 30, 24, false);
+        TextRect changedMerged = new("Settings Panel", 113, 100, 240, 30, 24, false);
         tracker.Update(fragments, imageSize, TimeSpan.Zero);
         tracker.Update([changedMerged], imageSize, TimeSpan.FromMilliseconds(500));
         Assert.Single(tracker.Update(

--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -232,6 +232,44 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void MinorityOverlapDoesNotCreateCompositeStructureReplacement()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect initial = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect[] neighboring =
+        [
+            new("Unrelated", 100, 112, 120, 30, 24, false),
+            new("Panel", 220, 112, 120, 30, 24, false),
+        ];
+        tracker.Update([initial], imageSize, TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> result = tracker.Update(
+            neighboring, imageSize, TimeSpan.FromMilliseconds(500));
+
+        Assert.Equal(["Menu", "Unrelated", "Panel"], result.Select(rect => rect.SourceText));
+    }
+
+    [Fact]
+    public void LargeFontSizeDifferenceDoesNotCreateCompositeStructureReplacement()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect initial = new("Logo", 100, 100, 240, 60, 48, false);
+        TextRect[] overlay =
+        [
+            new("Small", 100, 100, 120, 60, 24, false),
+            new("Caption", 220, 100, 120, 60, 24, false),
+        ];
+        tracker.Update([initial], imageSize, TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> result = tracker.Update(
+            overlay, imageSize, TimeSpan.FromMilliseconds(500));
+
+        Assert.Equal(["Logo", "Small", "Caption"], result.Select(rect => rect.SourceText));
+    }
+
+    [Fact]
     public void TemporaryTextChangeAndMergeKeepsTheStableFragments()
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
@@ -251,6 +289,120 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
 
         Assert.Equal(["Open", "Menu"], pending.Select(rect => rect.SourceText));
         Assert.Equal(["Open", "Menu"], recovered.Select(rect => rect.SourceText));
+    }
+
+    [Fact]
+    public void TemporaryTextChangeAndSplitKeepsTheStableWholeRegion()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect whole = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect[] changedSplit =
+        [
+            new("Open Settings", 100, 100, 150, 30, 24, false),
+            new("And Configure", 250, 100, 90, 30, 24, false),
+        ];
+        tracker.Update([whole], imageSize, TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> pending = tracker.Update(
+            changedSplit, imageSize, TimeSpan.FromMilliseconds(500));
+        IReadOnlyList<TextRect> recovered = tracker.Update(
+            [whole], imageSize, TimeSpan.FromMilliseconds(1000));
+
+        Assert.Equal("Menu", Assert.Single(pending).SourceText);
+        Assert.Equal("Menu", Assert.Single(recovered).SourceText);
+    }
+
+    [Fact]
+    public void PersistentTextAndLayoutChangeAndSplitConvergesWithoutDuplicate()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect whole = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect[] changedSplit =
+        [
+            new("Open Settings", 112, 100, 150, 30, 24, false),
+            new("And Configure", 262, 100, 90, 30, 24, false),
+        ];
+        tracker.Update([whole], imageSize, TimeSpan.Zero);
+
+        TextRect pending = Assert.Single(tracker.Update(
+            changedSplit, imageSize, TimeSpan.FromMilliseconds(500)));
+        TextRect confirmed = Assert.Single(tracker.Update(
+            changedSplit, imageSize, TimeSpan.FromMilliseconds(1000)));
+
+        Assert.Equal("Menu", pending.SourceText);
+        Assert.Equal("Open Settings And Configure", confirmed.SourceText);
+    }
+
+    [Fact]
+    public void ConfirmedCompositeSplitRestoresWithoutStaleTracks()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect whole = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect[] changedSplit =
+        [
+            new("Open Settings", 112, 100, 150, 30, 24, false),
+            new("And Configure", 262, 100, 90, 30, 24, false),
+        ];
+        tracker.Update([whole], imageSize, TimeSpan.Zero);
+        tracker.Update(changedSplit, imageSize, TimeSpan.FromMilliseconds(500));
+        Assert.Single(tracker.Update(
+            changedSplit, imageSize, TimeSpan.FromMilliseconds(1000)));
+
+        Assert.Single(tracker.Update(
+            [whole], imageSize, TimeSpan.FromMilliseconds(1500)));
+        TextRect restored = Assert.Single(tracker.Update(
+            [whole], imageSize, TimeSpan.FromMilliseconds(2000)));
+
+        Assert.Equal("Menu", restored.SourceText);
+    }
+
+    [Fact]
+    public void PersistentTextChangeAndMergeConvergesWithoutDuplicate()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect[] fragments =
+        [
+            new("Open", 100, 100, 90, 30, 24, false),
+            new("Menu", 200, 100, 140, 30, 24, false),
+        ];
+        TextRect changedMerged = new("Settings Panel", 100, 100, 240, 30, 24, false);
+        tracker.Update(fragments, imageSize, TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> pending = tracker.Update(
+            [changedMerged], imageSize, TimeSpan.FromMilliseconds(500));
+        TextRect confirmed = Assert.Single(tracker.Update(
+            [changedMerged], imageSize, TimeSpan.FromMilliseconds(1000)));
+
+        Assert.Equal(["Open", "Menu"], pending.Select(rect => rect.SourceText));
+        Assert.Equal("Settings Panel", confirmed.SourceText);
+    }
+
+    [Fact]
+    public void ConfirmedCompositeMergeRestoresWithoutStaleTracks()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect[] fragments =
+        [
+            new("Open", 100, 100, 90, 30, 24, false),
+            new("Menu", 200, 100, 140, 30, 24, false),
+        ];
+        TextRect changedMerged = new("Settings Panel", 100, 100, 240, 30, 24, false);
+        tracker.Update(fragments, imageSize, TimeSpan.Zero);
+        tracker.Update([changedMerged], imageSize, TimeSpan.FromMilliseconds(500));
+        Assert.Single(tracker.Update(
+            [changedMerged], imageSize, TimeSpan.FromMilliseconds(1000)));
+
+        Assert.Single(tracker.Update(
+            fragments, imageSize, TimeSpan.FromMilliseconds(1500)));
+        IReadOnlyList<TextRect> restored = tracker.Update(
+            fragments, imageSize, TimeSpan.FromMilliseconds(2000));
+
+        Assert.Equal(["Open", "Menu"], restored.Select(rect => rect.SourceText));
     }
 
     [Fact]

--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -134,6 +134,116 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void TextXAndWidthChangeStaysSingleAndConverges()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect initial = new("Menu", 300, 100, 100, 30, 24, false);
+        TextRect changed = new("Settings Menu", 250, 100, 200, 30, 24, false);
+        tracker.Update([initial], imageSize, TimeSpan.Zero);
+
+        TextRect pending = Assert.Single(tracker.Update(
+            [changed], imageSize, TimeSpan.FromMilliseconds(500)));
+        TextRect confirmed = Assert.Single(tracker.Update(
+            [changed], imageSize, TimeSpan.FromMilliseconds(1000)));
+
+        Assert.Equal(("Menu", 300, 100), (pending.SourceText, pending.X, pending.Width));
+        Assert.Equal(
+            ("Settings Menu", 250, 200),
+            (confirmed.SourceText, confirmed.X, confirmed.Width));
+    }
+
+    [Theory]
+    [InlineData(60)]
+    [InlineData(90)]
+    public void TextHeightAndMultiLineChangeStaysSingleAndConverges(double changedHeight)
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect initial = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect changed = new(
+            "Open Settings And Configure",
+            100,
+            100,
+            240,
+            changedHeight,
+            24,
+            true);
+        tracker.Update([initial], imageSize, TimeSpan.Zero);
+
+        TextRect pending = Assert.Single(tracker.Update(
+            [changed], imageSize, TimeSpan.FromMilliseconds(500)));
+        TextRect confirmed = Assert.Single(tracker.Update(
+            [changed], imageSize, TimeSpan.FromMilliseconds(1000)));
+
+        Assert.Equal(("Menu", 30, false), (pending.SourceText, pending.Height, pending.MultiLine));
+        Assert.Equal(
+            ("Open Settings And Configure", changedHeight, true),
+            (confirmed.SourceText, confirmed.Height, confirmed.MultiLine));
+
+        Assert.Single(tracker.Update(
+            [initial], imageSize, TimeSpan.FromMilliseconds(1500)));
+        TextRect restored = Assert.Single(tracker.Update(
+            [initial], imageSize, TimeSpan.FromMilliseconds(2000)));
+        Assert.Equal(
+            ("Menu", 30, false),
+            (restored.SourceText, restored.Height, restored.MultiLine));
+    }
+
+    [Theory]
+    [InlineData(100, 240, 60, 48, true)]
+    [InlineData(100, 240, 60, 24, false)]
+    [InlineData(130, 240, 90, 24, true)]
+    [InlineData(100, 180, 90, 24, true)]
+    public void UnrelatedLayoutChangeDoesNotUseMultilineContinuity(
+        double changedX,
+        double changedWidth,
+        double changedHeight,
+        double changedFontSize,
+        bool changedMultiLine)
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect initial = new("Menu", 100, 100, 240, 30, 24, false);
+        TextRect unrelated = new(
+            "Unrelated Panel",
+            changedX,
+            100,
+            changedWidth,
+            changedHeight,
+            changedFontSize,
+            changedMultiLine);
+        tracker.Update([initial], imageSize, TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> result = tracker.Update(
+            [unrelated], imageSize, TimeSpan.FromMilliseconds(500));
+
+        Assert.Equal(["Menu", "Unrelated Panel"], result.Select(rect => rect.SourceText));
+    }
+
+    [Fact]
+    public void TemporaryTextChangeAndMergeKeepsTheStableFragments()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect[] fragments =
+        [
+            new("Open", 100, 100, 90, 30, 24, false),
+            new("Menu", 200, 100, 140, 30, 24, false),
+        ];
+        TextRect changedMerged = new("Settings Panel", 100, 100, 240, 30, 24, false);
+        tracker.Update(fragments, imageSize, TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> pending = tracker.Update(
+            [changedMerged], imageSize, TimeSpan.FromMilliseconds(500));
+        IReadOnlyList<TextRect> recovered = tracker.Update(
+            fragments, imageSize, TimeSpan.FromMilliseconds(1000));
+
+        Assert.Equal(["Open", "Menu"], pending.Select(rect => rect.SourceText));
+        Assert.Equal(["Open", "Menu"], recovered.Select(rect => rect.SourceText));
+    }
+
+    [Fact]
     public void ContinuouslyChangingTextEventuallyAdvancesToTheLatestObservation()
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);

--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -154,21 +154,30 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(60)]
-    [InlineData(90)]
-    public void TextHeightAndMultiLineChangeStaysSingleAndConverges(double changedHeight)
+    [InlineData(100, 100, 240, 60, true)]
+    [InlineData(100, 100, 240, 90, true)]
+    [InlineData(130, 100, 240, 90, true)]
+    [InlineData(100, 100, 180, 90, true)]
+    [InlineData(100, 100, 240, 90, false)]
+    [InlineData(100, 110, 240, 30, false)]
+    public void TextAndLayoutChangeWithMajorityOverlapStaysSingleAndConverges(
+        double changedX,
+        double changedY,
+        double changedWidth,
+        double changedHeight,
+        bool changedMultiLine)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
         TextRect initial = new("Menu", 100, 100, 240, 30, 24, false);
         TextRect changed = new(
             "Open Settings And Configure",
-            100,
-            100,
-            240,
+            changedX,
+            changedY,
+            changedWidth,
             changedHeight,
             24,
-            true);
+            changedMultiLine);
         tracker.Update([initial], imageSize, TimeSpan.Zero);
 
         TextRect pending = Assert.Single(tracker.Update(
@@ -178,8 +187,8 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
 
         Assert.Equal(("Menu", 30, false), (pending.SourceText, pending.Height, pending.MultiLine));
         Assert.Equal(
-            ("Open Settings And Configure", changedHeight, true),
-            (confirmed.SourceText, confirmed.Height, confirmed.MultiLine));
+            ("Open Settings And Configure", changedX, changedY, changedWidth, changedHeight, changedMultiLine),
+            (confirmed.SourceText, confirmed.X, confirmed.Y, confirmed.Width, confirmed.Height, confirmed.MultiLine));
 
         Assert.Single(tracker.Update(
             [initial], imageSize, TimeSpan.FromMilliseconds(1500)));
@@ -191,34 +200,35 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(100, 240, 60, 48, true)]
-    [InlineData(100, 240, 60, 24, false)]
-    [InlineData(130, 240, 90, 24, true)]
-    [InlineData(100, 180, 90, 24, true)]
-    public void UnrelatedLayoutChangeDoesNotUseMultilineContinuity(
-        double changedX,
-        double changedWidth,
-        double changedHeight,
-        double changedFontSize,
-        bool changedMultiLine)
+    [InlineData(112)]
+    [InlineData(124)]
+    public void MinorityOverlapDoesNotReplaceNeighboringRegion(double neighboringY)
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);
         TextRect initial = new("Menu", 100, 100, 240, 30, 24, false);
-        TextRect unrelated = new(
-            "Unrelated Panel",
-            changedX,
-            100,
-            changedWidth,
-            changedHeight,
-            changedFontSize,
-            changedMultiLine);
+        TextRect neighboring = new("Unrelated Panel", 100, neighboringY, 240, 30, 24, false);
         tracker.Update([initial], imageSize, TimeSpan.Zero);
 
         IReadOnlyList<TextRect> result = tracker.Update(
-            [unrelated], imageSize, TimeSpan.FromMilliseconds(500));
+            [neighboring], imageSize, TimeSpan.FromMilliseconds(500));
 
         Assert.Equal(["Menu", "Unrelated Panel"], result.Select(rect => rect.SourceText));
+    }
+
+    [Fact]
+    public void LargeFontSizeDifferenceKeepsOverlappingRegionsSeparate()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect initial = new("Logo", 100, 100, 240, 60, 48, false);
+        TextRect overlay = new("Caption", 100, 100, 240, 60, 24, false);
+        tracker.Update([initial], imageSize, TimeSpan.Zero);
+
+        IReadOnlyList<TextRect> result = tracker.Update(
+            [overlay], imageSize, TimeSpan.FromMilliseconds(500));
+
+        Assert.Equal(["Logo", "Caption"], result.Select(rect => rect.SourceText));
     }
 
     [Fact]

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -28,6 +28,8 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
     private const double MinimumStructureTextSimilarity = 0.65;
     private const double MinimumMovingStructureTextSimilarity = 0.9;
     private const double MaximumStructureAngleDifference = 8;
+    private const double MinimumSameRegionCoverage = 0.65;
+    private const double MinimumSameRegionFontSizeRatio = 0.65;
     private const double StrongOneToOneScore = 0.9;
     private const double AngleVectorEpsilon = 0.000000000001;
     private static readonly TimeSpan dormantRetention = TimeSpan.FromSeconds(5);
@@ -127,6 +129,7 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             oneToOneCandidates
                 .Where(candidate => !reservedTracks.Contains(candidate.Tracks[0]))
                 .Where(candidate => !reservedObservations.Contains(candidate.ObservationIndices[0]))
+                .Where(candidate => !CoversReservedTextFragment(candidate.Combined, reservedTracks))
                 .ToArray()));
         this.ApplyMatches(selected, timestamp, matchedTracks, matchedObservations);
 
@@ -307,6 +310,17 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         => candidate.Score >= StrongOneToOneScore
             && candidate.Tracks[0].NormalizedConfirmedText
                 == normalizedObservations[candidate.ObservationIndices[0]];
+
+    private static bool CoversReservedTextFragment(
+        TextRect observation,
+        IReadOnlySet<TextTrack> reservedTracks)
+        => reservedTracks.Any(track =>
+        {
+            TextRect previous = track.LatestObservation;
+            return IsCoveredTextFragment(previous, observation)
+                && RatioSimilarity(previous.FontSize, observation.FontSize)
+                    >= MinimumSameRegionFontSizeRatio;
+        });
 
     private static MatchCandidate[] SelectOneToOne(IReadOnlyList<MatchCandidate> candidates)
     {
@@ -506,9 +520,15 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         double center = Math.Max(0, 1 - (centerDistance / distanceGate));
         double width = RatioSimilarity(previous.Width, observation.Width);
         double height = RatioSimilarity(previous.Height, observation.Height);
+        double fontSize = RatioSimilarity(previous.FontSize, observation.FontSize);
         double size = (width + height) / 2;
         double coverage = IntersectionOverSmallerArea(predicted, observation);
-        bool sameRegionGeometry = HasSameRegionGeometry(predicted, observation, coverage, height);
+        double sameRegionCoverage = Math.Max(
+            coverage,
+            IntersectionOverSmallerArea(previous, observation));
+        bool sameRegionOverlap = HasSameRegionOverlap(previous, observation, sameRegionCoverage);
+        bool compatibleFontSize = fontSize >= MinimumSameRegionFontSizeRatio;
+        bool sameRegionGeometry = sameRegionOverlap && compatibleFontSize;
         if (!CanReachTextSimilarity(trackText.Length, observationText.Length, 0.15)
             && overlap < 0.3
             && !sameRegionGeometry)
@@ -524,6 +544,10 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
 
         double text = NormalizedTextSimilarity(trackText, observationText);
         if (overlap == 0 && text < 0.9 && centerDistance > maximumDimension * 1.25)
+        {
+            return -1;
+        }
+        if (text < 0.65 && sameRegionOverlap && !compatibleFontSize)
         {
             return -1;
         }
@@ -550,35 +574,20 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         }
 
         double angle = Math.Max(0, 1 - (AngleDifference(predicted.Angle, observation.Angle) / 10));
-        double replacementScore = (overlap * 0.15)
+        double replacementScore = (sameRegionCoverage * 0.45)
             + (center * 0.2)
-            + (height * 0.2)
-            + (coverage * 0.25)
+            + (fontSize * 0.15)
             + (angle * 0.1)
-            + (recency * 0.05);
+            + (recency * 0.1);
         return Math.Max(score, replacementScore);
     }
 
-    private static bool HasSameRegionGeometry(
+    private static bool HasSameRegionOverlap(
         TextRect previous,
         TextRect observation,
-        double coverage,
-        double heightSimilarity)
-    {
-        double positionTolerance = Math.Max(3, Math.Min(previous.Height, observation.Height) * 0.2);
-        bool readingOriginAligned = Math.Abs(previous.X - observation.X) <= positionTolerance
-            && Math.Abs(previous.Y - observation.Y) <= positionTolerance;
-        bool centerAligned = CenterDistance(previous, observation) <= positionTolerance;
-        bool compatibleMultilineLayoutChange = previous.MultiLine != observation.MultiLine
-            && readingOriginAligned
-            && RatioSimilarity(previous.Width, observation.Width) >= 0.9
-            && RatioSimilarity(previous.FontSize, observation.FontSize) >= 0.8;
-        return coverage >= 0.8
-            && AngleDifference(previous.Angle, observation.Angle) <= MaximumStructureAngleDifference
-            && ((heightSimilarity >= MinimumStructureSizeRatio
-                    && (readingOriginAligned || centerAligned))
-                || compatibleMultilineLayoutChange);
-    }
+        double coverage)
+        => coverage >= MinimumSameRegionCoverage
+            && AngleDifference(previous.Angle, observation.Angle) <= MaximumStructureAngleDifference;
 
     private static bool TryCombineStructure(
         TextRect[] source,

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -144,6 +144,10 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             .Where(candidate => candidate.Kind is MatchKind.OneToOne or MatchKind.Split)
             .Select(candidate => candidate.Tracks[0])
             .ToHashSet();
+        HashSet<TextTrack> tracksWithReliableOutputGeometry = selected
+            .Where(HasReliableOutputGeometry)
+            .Select(candidate => candidate.Tracks[0])
+            .ToHashSet();
         this.ApplyMatches(selected, timestamp, matchedTracks, matchedObservations);
 
         for (int i = 0; i < current.Length; i++)
@@ -157,7 +161,9 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                 tracksWithCurrentGeometry.Add(track);
             }
         }
-        ResolveHistoricalGeometryConflicts(tracksWithCurrentGeometry);
+        ResolveHistoricalGeometryConflicts(
+            tracksWithReliableOutputGeometry,
+            tracksWithCurrentGeometry);
 
         foreach (TextTrack track in this.tracks.Where(track => !track.IsDormant).ToArray())
         {
@@ -194,15 +200,12 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
     }
 
     private static void ResolveHistoricalGeometryConflicts(
+        IReadOnlyCollection<TextTrack> tracksWithReliableOutputGeometry,
         IReadOnlyCollection<TextTrack> tracksWithCurrentGeometry)
     {
-        foreach (TextTrack track in tracksWithCurrentGeometry)
+        foreach (TextTrack track in tracksWithReliableOutputGeometry)
         {
-            bool hasHistoricalConflict = RatioSimilarity(track.Stabilized.Width, track.LatestObservation.Width)
-                    >= MinimumCompositeStructureSizeRatio
-                && RatioSimilarity(track.Stabilized.Height, track.LatestObservation.Height)
-                    >= MinimumCompositeStructureSizeRatio
-                && tracksWithCurrentGeometry.Any(other =>
+            bool hasHistoricalConflict = tracksWithCurrentGeometry.Any(other =>
                 !ReferenceEquals(track, other)
                 && IntersectionOverSmallerArea(track.Stabilized, other.LatestObservation)
                     > IntersectionOverSmallerArea(track.LatestObservation, other.LatestObservation)
@@ -212,6 +215,25 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                 track.UseLatestObservationGeometryForOutput();
             }
         }
+    }
+
+    private static bool HasReliableOutputGeometry(MatchCandidate candidate)
+    {
+        if (candidate.Kind == MatchKind.Split)
+        {
+            return true;
+        }
+        if (candidate.Kind != MatchKind.OneToOne)
+        {
+            return false;
+        }
+
+        TextTrack track = candidate.Tracks[0];
+        return track.NormalizedConfirmedText == NormalizeText(candidate.Combined.SourceText)
+            || (RatioSimilarity(track.Stabilized.Width, candidate.Combined.Width)
+                    >= MinimumCompositeStructureSizeRatio
+                && RatioSimilarity(track.Stabilized.Height, candidate.Combined.Height)
+                    >= MinimumCompositeStructureSizeRatio);
     }
 
     private static bool IsValid(TextRect rect)

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -29,6 +29,7 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
     private const double MinimumMovingStructureTextSimilarity = 0.9;
     private const double MaximumStructureAngleDifference = 8;
     private const double MinimumSameRegionCoverage = 0.65;
+    private const double MinimumCompositeStructureOverlap = 0.9;
     private const double MinimumSameRegionFontSizeRatio = 0.65;
     private const double StrongOneToOneScore = 0.9;
     private const double AngleVectorEpsilon = 0.000000000001;
@@ -199,6 +200,7 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         List<MatchCandidate> result = [];
         foreach (TextTrack track in tracks)
         {
+            List<(MatchCandidate Candidate, bool TextChanged)> trackCandidates = [];
             int[] nearby = Enumerable.Range(0, observations.Length)
                 .Where(index => !excludedObservations.Contains(index))
                 .Where(index => IsPotentialStructureMember(track.Stabilized, observations[index], imageSize))
@@ -222,18 +224,26 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                         track.NormalizedConfirmedText,
                         imageSize,
                         out TextRect combined,
-                        out double score))
+                        out double score,
+                        out bool textChanged))
                     {
-                        result.Add(new(MatchKind.Split, [track], members.ToArray(), combined, score));
+                        trackCandidates.Add((
+                            new(MatchKind.Split, [track], members.ToArray(), combined, score),
+                            textChanged));
                     }
                 }
             }
+            bool hasTextContinuity = trackCandidates.Any(candidate => !candidate.TextChanged);
+            result.AddRange(trackCandidates
+                .Where(candidate => !hasTextContinuity || !candidate.TextChanged)
+                .Select(candidate => candidate.Candidate));
         }
 
         foreach (int observationIndex in Enumerable.Range(0, observations.Length)
             .Where(index => !excludedObservations.Contains(index)))
         {
             TextRect observation = observations[observationIndex];
+            List<(MatchCandidate Candidate, bool TextChanged)> observationCandidates = [];
             TextTrack[] nearby = tracks
                 .Where(track => IsPotentialStructureMember(observation, track.Stabilized, imageSize))
                 .OrderBy(track => CenterDistance(observation, track.Stabilized))
@@ -256,12 +266,19 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                         normalizedObservations[observationIndex],
                         imageSize,
                         out _,
-                        out double score))
+                        out double score,
+                        out bool textChanged))
                     {
-                        result.Add(new(MatchKind.Merge, members.ToArray(), [observationIndex], observation, score));
+                        observationCandidates.Add((
+                            new(MatchKind.Merge, members.ToArray(), [observationIndex], observation, score),
+                            textChanged));
                     }
                 }
             }
+            bool hasTextContinuity = observationCandidates.Any(candidate => !candidate.TextChanged);
+            result.AddRange(observationCandidates
+                .Where(candidate => !hasTextContinuity || !candidate.TextChanged)
+                .Select(candidate => candidate.Candidate));
         }
         return result;
     }
@@ -597,8 +614,10 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         string normalizedTargetText,
         Size imageSize,
         out TextRect combined,
-        out double score)
+        out double score,
+        out bool textChangedWithStructure)
     {
+        textChangedWithStructure = false;
         (TextRect Rect, string Normalized)[] orderedMembers = OrderForReading(
             source.Select((rect, index) => (Rect: rect, Normalized: normalizedSource[index])),
             member => member.Rect)
@@ -631,21 +650,48 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             minimumTextSimilarity = MinimumMovingStructureTextSimilarity;
         }
 
-        if (!TrySelectCombinedText(
+        textChangedWithStructure = !TrySelectCombinedText(
             members,
             orderedMembers.Select(member => member.Normalized).ToArray(),
             targetText,
             normalizedTargetText,
             minimumTextSimilarity,
             out string text,
-            out double textSimilarity))
+            out double textSimilarity);
+        double sameRegionCoverage = IntersectionOverSmallerArea(geometry, targetRect);
+        double fontSizeSimilarity = RatioSimilarity(geometry.FontSize, targetRect.FontSize);
+        if (textChangedWithStructure)
         {
-            combined = default!;
-            score = -1;
-            return false;
+            bool sameLayerReplacement = HasSameRegionOverlap(
+                geometry,
+                targetRect,
+                sameRegionCoverage)
+                && overlap >= MinimumCompositeStructureOverlap
+                && fontSizeSimilarity >= MinimumSameRegionFontSizeRatio
+                && MembersRepresentDistinctRegions(members);
+            if (!sameLayerReplacement)
+            {
+                combined = default!;
+                score = -1;
+                textChangedWithStructure = false;
+                return false;
+            }
+            text = CombineChangedMemberText(members);
         }
 
         combined = geometry with { SourceText = text };
+        if (textChangedWithStructure)
+        {
+            double angle = Math.Max(
+                0,
+                1 - (AngleDifference(geometry.Angle, targetRect.Angle) / 10));
+            score = (sameRegionCoverage * 0.5)
+                + (fontSizeSimilarity * 0.2)
+                + (angle * 0.15)
+                + (overlap * 0.1)
+                + StructureAssignmentBonus;
+            return true;
+        }
         score = overlap >= MinimumStructureOverlap
             ? (overlap * 0.55) + (textSimilarity * 0.45) + StructureAssignmentBonus
             : (textSimilarity * 0.45)
@@ -693,6 +739,49 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         similarity = useSpaces ? withSpacesSimilarity : withoutSpacesSimilarity;
         return true;
     }
+
+    private static string CombineChangedMemberText(TextRect[] members)
+    {
+        StringBuilder text = new(members.Sum(member => member.SourceText.Length + 1));
+        for (int index = 0; index < members.Length; index++)
+        {
+            string memberText = members[index].SourceText;
+            if (index > 0
+                && text.Length > 0
+                && memberText.Length > 0
+                && !char.IsWhiteSpace(text[^1])
+                && !char.IsWhiteSpace(memberText[0])
+                && !IsNonSpacingScriptCharacter(text[^1])
+                && !IsNonSpacingScriptCharacter(memberText[0]))
+            {
+                text.Append(' ');
+            }
+            text.Append(memberText);
+        }
+        return text.ToString();
+    }
+
+    private static bool MembersRepresentDistinctRegions(TextRect[] members)
+    {
+        for (int first = 0; first < members.Length; first++)
+        {
+            for (int second = first + 1; second < members.Length; second++)
+            {
+                if (IntersectionOverSmallerArea(members[first], members[second])
+                    >= MinimumSameRegionCoverage)
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static bool IsNonSpacingScriptCharacter(char character)
+        => character is >= '\u2E80' and <= '\u9FFF'
+            or >= '\uAC00' and <= '\uD7AF'
+            or >= '\uF900' and <= '\uFAFF'
+            or >= '\uFF66' and <= '\uFF9F';
 
     private static bool CanReachTextSimilarity(int firstLength, int secondLength, double minimumSimilarity)
     {
@@ -987,7 +1076,8 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                         parent.NormalizedConfirmedText,
                         imageSize,
                         out TextRect combined,
-                        out double structureScore))
+                        out double structureScore,
+                        out _))
                     {
                         return;
                     }

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -29,7 +29,11 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
     private const double MinimumMovingStructureTextSimilarity = 0.9;
     private const double MaximumStructureAngleDifference = 8;
     private const double MinimumSameRegionCoverage = 0.65;
-    private const double MinimumCompositeStructureOverlap = 0.9;
+    private const double MinimumNearlyIdenticalRegionOverlap = 0.9;
+    private const double MinimumShiftedCompositeStructureOverlap = 0.85;
+    private const double MinimumCompositeStructureSizeRatio = 0.9;
+    private const double MinimumCompositeStructureCenterOffsetWidthRatio = 0.05;
+    private const double MaximumCompositeStructureCenterOffsetHeightRatio = 0.5;
     private const double MinimumSameRegionFontSizeRatio = 0.65;
     private const double StrongOneToOneScore = 0.9;
     private const double AngleVectorEpsilon = 0.000000000001;
@@ -540,12 +544,17 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         double fontSize = RatioSimilarity(previous.FontSize, observation.FontSize);
         double size = (width + height) / 2;
         double coverage = IntersectionOverSmallerArea(predicted, observation);
+        double sameRegionIoU = Math.Max(
+            overlap,
+            IntersectionOverUnion(previous, observation));
         double sameRegionCoverage = Math.Max(
             coverage,
             IntersectionOverSmallerArea(previous, observation));
         bool sameRegionOverlap = HasSameRegionOverlap(previous, observation, sameRegionCoverage);
         bool compatibleFontSize = fontSize >= MinimumSameRegionFontSizeRatio;
-        bool sameRegionGeometry = sameRegionOverlap && compatibleFontSize;
+        bool sameRegionGeometry = sameRegionOverlap
+            && (compatibleFontSize
+                || sameRegionIoU >= MinimumNearlyIdenticalRegionOverlap);
         if (!CanReachTextSimilarity(trackText.Length, observationText.Length, 0.15)
             && overlap < 0.3
             && !sameRegionGeometry)
@@ -564,7 +573,10 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         {
             return -1;
         }
-        if (text < 0.65 && sameRegionOverlap && !compatibleFontSize)
+        if (text < 0.65
+            && sameRegionOverlap
+            && !compatibleFontSize
+            && sameRegionIoU < MinimumNearlyIdenticalRegionOverlap)
         {
             return -1;
         }
@@ -662,11 +674,11 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         double fontSizeSimilarity = RatioSimilarity(geometry.FontSize, targetRect.FontSize);
         if (textChangedWithStructure)
         {
-            bool sameLayerReplacement = HasSameRegionOverlap(
+            bool sameLayerReplacement = HasCompatibleCompositeGeometry(
                 geometry,
                 targetRect,
+                overlap,
                 sameRegionCoverage)
-                && overlap >= MinimumCompositeStructureOverlap
                 && fontSizeSimilarity >= MinimumSameRegionFontSizeRatio
                 && MembersRepresentDistinctRegions(members);
             if (!sameLayerReplacement)
@@ -775,6 +787,39 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             }
         }
         return true;
+    }
+
+    private static bool HasCompatibleCompositeGeometry(
+        TextRect geometry,
+        TextRect targetRect,
+        double overlap,
+        double coverage)
+    {
+        if (!HasSameRegionOverlap(geometry, targetRect, coverage))
+        {
+            return false;
+        }
+        if (overlap >= MinimumNearlyIdenticalRegionOverlap)
+        {
+            return true;
+        }
+
+        double centerDistance = CenterDistance(geometry, targetRect);
+        double minimumCenterOffset = Math.Max(
+            1,
+            Math.Min(geometry.Width, targetRect.Width)
+                * MinimumCompositeStructureCenterOffsetWidthRatio);
+        double maximumCenterOffset = Math.Max(
+            3,
+            Math.Min(geometry.Height, targetRect.Height)
+                * MaximumCompositeStructureCenterOffsetHeightRatio);
+        return overlap >= MinimumShiftedCompositeStructureOverlap
+            && RatioSimilarity(geometry.Width, targetRect.Width)
+                >= MinimumCompositeStructureSizeRatio
+            && RatioSimilarity(geometry.Height, targetRect.Height)
+                >= MinimumCompositeStructureSizeRatio
+            && centerDistance >= minimumCenterOffset
+            && centerDistance <= maximumCenterOffset;
     }
 
     private static bool IsNonSpacingScriptCharacter(char character)

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -75,6 +75,10 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
     private TextRect[] UpdateCore(IEnumerable<TextRect> observations, Size imageSize, TimeSpan timestamp)
     {
         TextRect[] current = observations.Where(IsValid).ToArray();
+        foreach (TextTrack track in this.tracks)
+        {
+            track.ClearOutputGeometryOverride();
+        }
         if (this.tracks.Count == 0)
         {
             foreach (TextRect observation in current)
@@ -136,6 +140,10 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                 .Where(candidate => !reservedObservations.Contains(candidate.ObservationIndices[0]))
                 .Where(candidate => !CoversReservedTextFragment(candidate.Combined, reservedTracks))
                 .ToArray()));
+        HashSet<TextTrack> tracksWithCurrentGeometry = selected
+            .Where(candidate => candidate.Kind is MatchKind.OneToOne or MatchKind.Split)
+            .Select(candidate => candidate.Tracks[0])
+            .ToHashSet();
         this.ApplyMatches(selected, timestamp, matchedTracks, matchedObservations);
 
         for (int i = 0; i < current.Length; i++)
@@ -146,8 +154,10 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                     IsCoveredTextFragment(current[i], track.Stabilized));
                 TextTrack track = this.CreateTrack(current[i], timestamp, coveringTrack?.Id);
                 matchedTracks.Add(track);
+                tracksWithCurrentGeometry.Add(track);
             }
         }
+        ResolveHistoricalGeometryConflicts(tracksWithCurrentGeometry);
 
         foreach (TextTrack track in this.tracks.Where(track => !track.IsDormant).ToArray())
         {
@@ -181,6 +191,27 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         }
 
         return this.GetOutput();
+    }
+
+    private static void ResolveHistoricalGeometryConflicts(
+        IReadOnlyCollection<TextTrack> tracksWithCurrentGeometry)
+    {
+        foreach (TextTrack track in tracksWithCurrentGeometry)
+        {
+            bool hasHistoricalConflict = RatioSimilarity(track.Stabilized.Width, track.LatestObservation.Width)
+                    >= MinimumCompositeStructureSizeRatio
+                && RatioSimilarity(track.Stabilized.Height, track.LatestObservation.Height)
+                    >= MinimumCompositeStructureSizeRatio
+                && tracksWithCurrentGeometry.Any(other =>
+                !ReferenceEquals(track, other)
+                && IntersectionOverSmallerArea(track.Stabilized, other.LatestObservation)
+                    > IntersectionOverSmallerArea(track.LatestObservation, other.LatestObservation)
+                        + double.Epsilon);
+            if (hasHistoricalConflict)
+            {
+                track.UseLatestObservationGeometryForOutput();
+            }
+        }
     }
 
     private static bool IsValid(TextRect rect)
@@ -552,9 +583,14 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             IntersectionOverSmallerArea(previous, observation));
         bool sameRegionOverlap = HasSameRegionOverlap(previous, observation, sameRegionCoverage);
         bool compatibleFontSize = fontSize >= MinimumSameRegionFontSizeRatio;
+        bool centeredSameRegion = sameRegionCoverage >= MinimumNearlyIdenticalRegionOverlap
+            && width >= MinimumCompositeStructureSizeRatio
+            && CenterDistance(previous, observation)
+                <= Math.Max(3, Math.Min(previous.Height, observation.Height) * 0.25);
         bool sameRegionGeometry = sameRegionOverlap
             && (compatibleFontSize
-                || sameRegionIoU >= MinimumNearlyIdenticalRegionOverlap);
+                || sameRegionIoU >= MinimumNearlyIdenticalRegionOverlap
+                || centeredSameRegion);
         if (!CanReachTextSimilarity(trackText.Length, observationText.Length, 0.15)
             && overlap < 0.3
             && !sameRegionGeometry)
@@ -576,7 +612,8 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         if (text < 0.65
             && sameRegionOverlap
             && !compatibleFontSize
-            && sameRegionIoU < MinimumNearlyIdenticalRegionOverlap)
+            && sameRegionIoU < MinimumNearlyIdenticalRegionOverlap
+            && !centeredSameRegion)
         {
             return -1;
         }
@@ -1660,7 +1697,7 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         => this.tracks
             .Where(track => !track.IsDormant)
             .OrderBy(track => track.Id)
-            .Select(track => track.Stabilized)
+            .Select(track => track.Output)
             .ToArray();
 
     private enum MatchKind
@@ -1773,6 +1810,7 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         private readonly List<TextVote> textVotes = [];
         private string normalizedConfirmedText = NormalizeText(observation.SourceText);
         private DormantGeometry? dormantGeometry;
+        private TextRect? outputGeometryOverride;
         private double velocityX;
         private double velocityY;
         private int motionSamples;
@@ -1782,6 +1820,19 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         public TextRect LatestObservation { get; private set; } = observation;
 
         public TextRect Stabilized { get; private set; } = observation;
+
+        public TextRect Output => this.outputGeometryOverride is TextRect geometry
+            ? this.Stabilized with
+            {
+                X = geometry.X,
+                Y = geometry.Y,
+                Width = geometry.Width,
+                Height = geometry.Height,
+                FontSize = geometry.FontSize,
+                MultiLine = geometry.MultiLine,
+                Angle = geometry.Angle,
+            }
+            : this.Stabilized;
 
         public string ConfirmedText { get; private set; } = observation.SourceText;
 
@@ -2046,6 +2097,12 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             this.geometryCandidate = null;
             this.geometryCandidateCount = 0;
         }
+
+        public void UseLatestObservationGeometryForOutput()
+            => this.outputGeometryOverride = this.LatestObservation;
+
+        public void ClearOutputGeometryOverride()
+            => this.outputGeometryOverride = null;
 
         private sealed record DormantGeometry(
             double AlongOffsetRatio,

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -148,6 +148,25 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             .Where(HasReliableOutputGeometry)
             .Select(candidate => candidate.Tracks[0])
             .ToHashSet();
+        List<OutputGeometry[]> reliableMergeOutputGeometryGroups = [];
+        Dictionary<TextTrack, TextRect> mergeOutputGeometries = [];
+        foreach (MatchCandidate candidate in selected.Where(candidate => candidate.Kind == MatchKind.Merge))
+        {
+            TextRect previousUnion = Union(
+                candidate.Tracks.Select(track => track.Stabilized).ToArray(),
+                string.Empty);
+            OutputGeometry[] group = candidate.Tracks
+                .Select(track => new OutputGeometry(
+                    track,
+                    track.ProjectOutputGeometry(previousUnion, candidate.Combined)))
+                .ToArray();
+            foreach (OutputGeometry outputGeometry in group)
+            {
+                tracksWithCurrentGeometry.Add(outputGeometry.Track);
+                mergeOutputGeometries[outputGeometry.Track] = outputGeometry.Geometry;
+            }
+            reliableMergeOutputGeometryGroups.Add(group);
+        }
         this.ApplyMatches(selected, timestamp, matchedTracks, matchedObservations);
 
         for (int i = 0; i < current.Length; i++)
@@ -163,7 +182,9 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         }
         ResolveHistoricalGeometryConflicts(
             tracksWithReliableOutputGeometry,
-            tracksWithCurrentGeometry);
+            reliableMergeOutputGeometryGroups,
+            tracksWithCurrentGeometry,
+            mergeOutputGeometries);
 
         foreach (TextTrack track in this.tracks.Where(track => !track.IsDormant).ToArray())
         {
@@ -201,21 +222,53 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
 
     private static void ResolveHistoricalGeometryConflicts(
         IReadOnlyCollection<TextTrack> tracksWithReliableOutputGeometry,
-        IReadOnlyCollection<TextTrack> tracksWithCurrentGeometry)
+        IReadOnlyCollection<OutputGeometry[]> reliableMergeOutputGeometryGroups,
+        IReadOnlyCollection<TextTrack> tracksWithCurrentGeometry,
+        IReadOnlyDictionary<TextTrack, TextRect> mergeOutputGeometries)
     {
         foreach (TextTrack track in tracksWithReliableOutputGeometry)
         {
             bool hasHistoricalConflict = tracksWithCurrentGeometry.Any(other =>
                 !ReferenceEquals(track, other)
-                && IntersectionOverSmallerArea(track.Stabilized, other.LatestObservation)
-                    > IntersectionOverSmallerArea(track.LatestObservation, other.LatestObservation)
+                && IntersectionOverSmallerArea(
+                    track.Stabilized,
+                    CurrentOutputGeometry(other, mergeOutputGeometries))
+                    > IntersectionOverSmallerArea(
+                        track.LatestObservation,
+                        CurrentOutputGeometry(other, mergeOutputGeometries))
                         + double.Epsilon);
             if (hasHistoricalConflict)
             {
-                track.UseLatestObservationGeometryForOutput();
+                track.UseOutputGeometry(track.LatestObservation);
+            }
+        }
+
+        foreach (OutputGeometry[] group in reliableMergeOutputGeometryGroups)
+        {
+            bool hasHistoricalConflict = group.Any(outputGeometry =>
+                tracksWithCurrentGeometry.Any(other =>
+                    !group.Any(member => ReferenceEquals(member.Track, other))
+                    && IntersectionOverSmallerArea(
+                        outputGeometry.Track.Stabilized,
+                        CurrentOutputGeometry(other, mergeOutputGeometries))
+                        > IntersectionOverSmallerArea(
+                            outputGeometry.Geometry,
+                            CurrentOutputGeometry(other, mergeOutputGeometries))
+                            + double.Epsilon));
+            if (hasHistoricalConflict)
+            {
+                foreach (OutputGeometry outputGeometry in group)
+                {
+                    outputGeometry.Track.UseOutputGeometry(outputGeometry.Geometry);
+                }
             }
         }
     }
+
+    private static TextRect CurrentOutputGeometry(
+        TextTrack track,
+        IReadOnlyDictionary<TextTrack, TextRect> mergeOutputGeometries)
+        => mergeOutputGeometries.GetValueOrDefault(track, track.LatestObservation);
 
     private static bool HasReliableOutputGeometry(MatchCandidate candidate)
     {
@@ -1732,6 +1785,8 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
 
     private sealed record RestorationAssignment(TextTrack Track, int ObservationIndex, TextRect Observation);
 
+    private sealed record OutputGeometry(TextTrack Track, TextRect Geometry);
+
     private readonly struct StructureResourceMask :
         IEquatable<StructureResourceMask>,
         IComparable<StructureResourceMask>
@@ -2120,8 +2175,12 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             this.geometryCandidateCount = 0;
         }
 
-        public void UseLatestObservationGeometryForOutput()
-            => this.outputGeometryOverride = this.LatestObservation;
+        public TextRect ProjectOutputGeometry(TextRect previousParent, TextRect currentParent)
+            => DormantGeometry.Create(this.Stabilized, previousParent)
+                .Restore(this.Stabilized, currentParent);
+
+        public void UseOutputGeometry(TextRect geometry)
+            => this.outputGeometryOverride = geometry;
 
         public void ClearOutputGeometryOverride()
             => this.outputGeometryOverride = null;

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -569,10 +569,15 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         bool readingOriginAligned = Math.Abs(previous.X - observation.X) <= positionTolerance
             && Math.Abs(previous.Y - observation.Y) <= positionTolerance;
         bool centerAligned = CenterDistance(previous, observation) <= positionTolerance;
+        bool compatibleMultilineLayoutChange = previous.MultiLine != observation.MultiLine
+            && readingOriginAligned
+            && RatioSimilarity(previous.Width, observation.Width) >= 0.9
+            && RatioSimilarity(previous.FontSize, observation.FontSize) >= 0.8;
         return coverage >= 0.8
-            && heightSimilarity >= MinimumStructureSizeRatio
             && AngleDifference(previous.Angle, observation.Angle) <= MaximumStructureAngleDifference
-            && (readingOriginAligned || centerAligned);
+            && ((heightSimilarity >= MinimumStructureSizeRatio
+                    && (readingOriginAligned || centerAligned))
+                || compatibleMultilineLayoutChange);
     }
 
     private static bool TryCombineStructure(


### PR DESCRIPTION
## 概要

OCR結果の文字列、矩形、MultiLine、分割・統合が同時に変化しても、タイムスライス間の情報を使って同じ論理領域を追跡できるようにしました。

通常のOCR結果と最終的な追跡結果は基本的に重ならないことを前提とします。同じ矩形、または同じ表示領域で文字列が変わった場合は、重層表示ではなく時間方向のテキスト切り替わりとして同じトラックを維持します。

ロゴと小さいキャプションのように、同一フレームでフォントサイズと矩形サイズが大きく異なる特殊な重層表示は別トラックとして維持します。小さい矩形を前面にする既存の描画順には手を加えていません。

Fixes #652

## 変更内容

- 文字列変更とX座標・幅変更、または高さ・MultiLine変更が同時に起きても、既存トラックで一時変化を抑制し、継続後に新しい内容と矩形へ収束
- 文字列も同時に変わるOCR分割・統合を、構成矩形の文字列、合成範囲、フォントサイズ、角度、構成矩形同士の独立性から判定
- 文字列の連続性がある通常の分割・統合候補を、文字列も変化する複合候補より優先
- 確定した分割・統合が元の構造へ戻った場合、古い断片や統合領域を残さず復元
- 現在フレームで位置の異なる新規矩形を既存トラックへ吸収せず、初回から表示
- 追跡用の安定矩形は保持したまま、過去の矩形だけが現在の別領域へ重なるフレームでは、表示用矩形を現在の対応範囲へ一時的に追従
- 表示用の現在形状は、互換スタイルの複数OCR矩形から成立した分割対応ではサイズ変化に関係なく採用
- 1対1対応では、同じ文字列の継続、または新旧矩形が同規模の場合だけ現在形状を信頼し、フォントが不揃いな特殊重層表示の弱い対応を除外
- 同一領域の時間変化と、フォントサイズ・矩形サイズが大きく異なる特殊な重層表示を分離

## 回帰テスト

- 文字列＋X座標＋幅変更
- 文字列＋高さ＋MultiLine変更
- 同じ表示領域での文字列変更＋OCR分割
  - 一時変化
  - 継続後の収束
  - 元構造への復帰
- 同じ表示領域での文字列変更＋OCR統合
  - 一時変化
  - 継続後の収束
  - 元構造への復帰
- 既存トラックの移動・分割と、位置の異なる新規 `Settings` の同時追加
- 既存トラックの移動・統合と、位置の異なる新規 `Settings` の同時追加
- フォントサイズ24→16、幅100→70、高さ30→20を伴う移動・分割でも、過去矩形を残さず現在の非重複矩形を使用
- 同一フレームの通常領域に矩形化由来の軽微な交差があっても別トラックとして維持
- 同一表示領域でのフォントサイズ変更を時間方向の切り替わりとして追跡
- 大きいロゴと小さいキャプション、およびフォントが不揃いな断片を特殊重層表示として維持
- 既存の構造選択、割当て、移動予測、復元、性能、ランダム追跡テスト

## 検証

- `dotnet test WindowTranslator.Tests\WindowTranslator.Tests.csproj --filter "FullyQualifiedName~ShiftedSplitWithFontSizeChangeAndNewRegionUsesCurrentNonOverlappingGeometry|FullyQualifiedName~ShiftedSplitWithNewRegionUsesCurrentNonOverlappingGeometry|FullyQualifiedName~ShiftedMergeWithNewRegionUsesCurrentNonOverlappingGeometry|FullyQualifiedName~WholeRegionRemovesFragmentsCreatedWhileTheParentWasUnmatched|FullyQualifiedName~DistinctSmallOverlayRemainsSeparateFromLargeRegion|FullyQualifiedName~DistinctSmallOverlayFragmentsDoNotReplaceLargeRegion" -m:1 -nr:false -p:BuildInParallel=false -p:UseSharedCompilation=false --logger "console;verbosity=normal"`
- `dotnet test WindowTranslator.Tests\WindowTranslator.Tests.csproj --no-build --no-restore -m:1 -nr:false -p:BuildInParallel=false -p:UseSharedCompilation=false --logger "console;verbosity=detailed"`
- 対象テスト 6/6 成功
- 全テスト 78/78 成功
- 固定シナリオ精度 100.00%
- seeded randomized 平均精度 90.22%
- `git diff --check` 成功
