### PR TITLE
OcrTextTracker の Geometry ノイズを代表値へ収束させる

### DIFF
--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -619,6 +619,96 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void PeriodicPositionAndFontSizeNoiseDoesNotOscillate()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect stable = new("Panel", 100, 100, 100, 30, 24, false);
+        TextRect jittered = stable with { X = 102, FontSize = 25 };
+        tracker.Update([stable], imageSize, TimeSpan.Zero);
+
+        for (int frame = 1; frame <= 12; frame++)
+        {
+            TextRect observation = frame % 2 == 1 ? jittered : stable;
+            TextRect result = Assert.Single(tracker.Update(
+                [observation],
+                imageSize,
+                TimeSpan.FromMilliseconds(frame * 500)));
+
+            Assert.Equal((100, 24), (result.X, result.FontSize));
+        }
+    }
+
+    [Fact]
+    public void SingleGeometryOutlierDoesNotMoveStableGeometry()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect stable = new("Panel", 100, 100, 100, 30, 24, false);
+        tracker.Update([stable], imageSize, TimeSpan.Zero);
+
+        double[] observations = [100, 100, 115, 100];
+        for (int frame = 0; frame < observations.Length; frame++)
+        {
+            TextRect result = Assert.Single(tracker.Update(
+                [stable with { X = observations[frame] }],
+                imageSize,
+                TimeSpan.FromMilliseconds((frame + 1) * 500)));
+
+            Assert.Equal(100, result.X);
+        }
+    }
+
+    [Fact]
+    public void PersistentNoiseGeometryConvergesForEveryGeometryValue()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect initial = new("Panel", 100, 100, 100, 30, 24, false) { Angle = 359 };
+        TextRect changed = initial with
+        {
+            X = 102,
+            Y = 102,
+            Width = 102,
+            Height = 32,
+            FontSize = 25,
+            MultiLine = true,
+            Angle = 1,
+        };
+        tracker.Update([initial], imageSize, TimeSpan.Zero);
+
+        TextRect result = initial;
+        for (int frame = 1; frame <= 4; frame++)
+        {
+            result = Assert.Single(tracker.Update(
+                [changed],
+                imageSize,
+                TimeSpan.FromMilliseconds(frame * 500)));
+        }
+
+        Assert.Equal(
+            (changed.X, changed.Y, changed.Width, changed.Height, changed.FontSize, changed.MultiLine, changed.Angle),
+            (result.X, result.Y, result.Width, result.Height, result.FontSize, result.MultiLine, result.Angle));
+    }
+
+    [Fact]
+    public void LargeGeometryMovementIsStillAppliedImmediately()
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect initial = new("Panel", 100, 100, 100, 30, 24, false);
+        TextRect moved = initial with { X = 180 };
+        tracker.Update([initial], imageSize, TimeSpan.Zero);
+
+        TextRect result = Assert.Single(tracker.Update(
+            [moved],
+            imageSize,
+            TimeSpan.FromMilliseconds(500)));
+
+        Assert.Equal(180, result.X);
+    }
+
+    [Fact]
     public void NonFiniteGeometryIsRejected()
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
@@ -1368,16 +1458,19 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         TextRect changed = initial with { X = 110, Width = 110 };
         tracker.Update([initial], imageSize, TimeSpan.Zero);
 
-        TextRect first = Assert.Single(tracker.Update(
-            [changed],
-            imageSize,
-            TimeSpan.FromMilliseconds(500)));
-        TextRect confirmed = Assert.Single(tracker.Update(
-            [changed],
-            imageSize,
-            TimeSpan.FromMilliseconds(1000)));
+        TextRect confirmed = initial;
+        for (int frame = 1; frame <= 4; frame++)
+        {
+            confirmed = Assert.Single(tracker.Update(
+                [changed],
+                imageSize,
+                TimeSpan.FromMilliseconds(frame * 500)));
+            if (frame < 4)
+            {
+                Assert.Equal((100, 100), (confirmed.X, confirmed.Width));
+            }
+        }
 
-        Assert.Equal((100, 100), (first.X, first.Width));
         Assert.Equal((110, 110), (confirmed.X, confirmed.Width));
     }
 

--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -664,7 +664,7 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void SingleGeometryOutlierDoesNotMoveStableGeometry()
+    public void SingleNoiseRangeGeometryOutlierDoesNotMoveStableGeometry()
     {
         OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
         Size imageSize = new(1000, 600);

--- a/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
+++ b/WindowTranslator.Tests/OcrTextTrackerAccuracyTests.cs
@@ -639,6 +639,30 @@ public class OcrTextTrackerAccuracyTests(ITestOutputHelper output)
         }
     }
 
+    [Theory]
+    [InlineData(40, 10)]
+    [InlineData(10, 40)]
+    public void PeriodicFontSizeChangesOutsideTheNoiseRangeDoNotConfirmEitherExtreme(
+        double first,
+        double second)
+    {
+        OcrTextTracker tracker = new(NullLogger<OcrTextTracker>.Instance);
+        Size imageSize = new(1000, 600);
+        TextRect stable = new("Panel", 100, 100, 100, 30, 24, false);
+        tracker.Update([stable], imageSize, TimeSpan.Zero);
+
+        for (int frame = 1; frame <= 12; frame++)
+        {
+            double fontSize = frame % 2 == 1 ? first : second;
+            TextRect result = Assert.Single(tracker.Update(
+                [stable with { FontSize = fontSize }],
+                imageSize,
+                TimeSpan.FromMilliseconds(frame * 500)));
+
+            Assert.Equal(24, result.FontSize);
+        }
+    }
+
     [Fact]
     public void SingleGeometryOutlierDoesNotMoveStableGeometry()
     {

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -2176,6 +2176,7 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
             => CenterDistance(candidate, current) <= Math.Max(3, Math.Max(candidate.Width, candidate.Height) * 0.15)
                 && RatioSimilarity(candidate.Width, current.Width) >= 0.85
                 && RatioSimilarity(candidate.Height, current.Height) >= 0.85
+                && RatioSimilarity(candidate.FontSize, current.FontSize) >= 0.85
                 && AngleDifference(candidate.Angle, current.Angle) <= 3
                 && candidate.MultiLine == current.MultiLine;
 

--- a/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
+++ b/WindowTranslator/Modules/Ocr/OcrTextTracker.cs
@@ -14,7 +14,8 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
 {
     private const int MaxMissedFrames = 3;
     private const int StructureConfirmationFrames = 2;
-    private const int MicroGeometryConfirmationFrames = 4;
+    private const int NormalGeometryConfirmationFrames = 2;
+    private const int NoiseGeometrySampleCount = 5;
     private const int MaxStructureCandidates = 6;
     private const int MaxStructureSelectionStates = 1024;
     private const int MaxOneToOneCandidatesPerResource = 3;
@@ -1882,8 +1883,9 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
         TimeSpan timestamp,
         long? coveringTrackId)
     {
-        private TextRect? geometryCandidate;
-        private int geometryCandidateCount;
+        private TextRect? normalGeometryCandidate;
+        private int normalGeometryCandidateCount;
+        private readonly List<TextRect> noiseGeometrySamples = [];
         private readonly List<TextVote> textVotes = [];
         private string normalizedConfirmedText = NormalizeText(observation.SourceText);
         private DormantGeometry? dormantGeometry;
@@ -2082,15 +2084,6 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
 
         private void UpdateGeometry(TextRect current)
         {
-            bool isNoise = IsGeometryNoise(this.Stabilized, current);
-            bool matchesStable = isNoise && GeometrySamplesMatch(this.Stabilized, current);
-            if (matchesStable && GeometryValuesEqual(this.Stabilized, current))
-            {
-                this.geometryCandidate = null;
-                this.geometryCandidateCount = 0;
-                return;
-            }
-
             double movement = CenterDistance(this.Stabilized, current);
             if (movement > Math.Max(this.Stabilized.Width, this.Stabilized.Height) * 0.75)
             {
@@ -2098,24 +2091,37 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                 return;
             }
 
-            if (this.geometryCandidate is not null
-                && (isNoise
-                    ? GeometrySamplesMatch(this.geometryCandidate, current)
-                    : GeometryCandidateMatches(this.geometryCandidate, current)))
+            if (IsGeometryNoise(this.Stabilized, current))
             {
-                this.geometryCandidate = current;
-                this.geometryCandidateCount++;
+                this.normalGeometryCandidate = null;
+                this.normalGeometryCandidateCount = 0;
+                if (this.noiseGeometrySamples.Count == 0)
+                {
+                    this.noiseGeometrySamples.Add(this.Stabilized);
+                }
+
+                this.noiseGeometrySamples.Add(current);
+                if (this.noiseGeometrySamples.Count >= NoiseGeometrySampleCount)
+                {
+                    this.ApplyGeometry(RepresentativeGeometry(this.noiseGeometrySamples));
+                }
+                return;
+            }
+
+            this.noiseGeometrySamples.Clear();
+            if (this.normalGeometryCandidate is not null
+                && GeometryCandidateMatches(this.normalGeometryCandidate, current))
+            {
+                this.normalGeometryCandidate = current;
+                this.normalGeometryCandidateCount++;
             }
             else
             {
-                this.geometryCandidate = current;
-                this.geometryCandidateCount = 1;
+                this.normalGeometryCandidate = current;
+                this.normalGeometryCandidateCount = 1;
             }
 
-            int confirmationFrames = matchesStable
-                ? MicroGeometryConfirmationFrames
-                : StructureConfirmationFrames;
-            if (this.geometryCandidateCount >= confirmationFrames)
+            if (this.normalGeometryCandidateCount >= NormalGeometryConfirmationFrames)
             {
                 this.ApplyGeometry(current);
             }
@@ -2130,27 +2136,41 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                 && Math.Abs(stable.Width - current.Width) <= Math.Max(3, stable.Width * 0.12)
                 && Math.Abs(stable.Height - current.Height) <= Math.Max(3, stable.Height * 0.12)
                 && Math.Abs(stable.FontSize - current.FontSize) <= Math.Max(1, stable.FontSize * 0.12)
-                && AngleDifference(stable.Angle, current.Angle) <= 2
-                && stable.MultiLine == current.MultiLine;
+                && AngleDifference(stable.Angle, current.Angle) <= 2;
         }
 
-        private static bool GeometrySamplesMatch(TextRect first, TextRect second)
-            => Math.Abs(first.X - second.X) <= 1
-                && Math.Abs(first.Y - second.Y) <= 1
-                && Math.Abs(first.Width - second.Width) <= 1
-                && Math.Abs(first.Height - second.Height) <= 1
-                && Math.Abs(first.FontSize - second.FontSize) <= 0.5
-                && AngleDifference(first.Angle, second.Angle) <= 2
-                && first.MultiLine == second.MultiLine;
+        private static TextRect RepresentativeGeometry(List<TextRect> samples)
+            => samples[0] with
+            {
+                X = Median(samples.Select(sample => sample.X)),
+                Y = Median(samples.Select(sample => sample.Y)),
+                Width = Median(samples.Select(sample => sample.Width)),
+                Height = Median(samples.Select(sample => sample.Height)),
+                FontSize = Median(samples.Select(sample => sample.FontSize)),
+                Angle = MedianAngle(samples),
+                MultiLine = samples.Count(sample => sample.MultiLine) > samples.Count / 2,
+            };
 
-        private static bool GeometryValuesEqual(TextRect first, TextRect second)
-            => first.X == second.X
-                && first.Y == second.Y
-                && first.Width == second.Width
-                && first.Height == second.Height
-                && first.FontSize == second.FontSize
-                && first.Angle == second.Angle
-                && first.MultiLine == second.MultiLine;
+        private static double Median(IEnumerable<double> values)
+        {
+            double[] ordered = values.Order().ToArray();
+            return ordered[ordered.Length / 2];
+        }
+
+        private static double MedianAngle(List<TextRect> samples)
+            => samples
+                .Select((sample, index) => new
+                {
+                    sample.Angle,
+                    Index = index,
+                    Distance = samples.Sum(other => AngleDifference(sample.Angle, other.Angle)),
+                    StableDistance = AngleDifference(samples[0].Angle, sample.Angle),
+                })
+                .OrderBy(candidate => candidate.Distance)
+                .ThenBy(candidate => candidate.StableDistance)
+                .ThenBy(candidate => candidate.Index)
+                .First()
+                .Angle;
 
         private static bool GeometryCandidateMatches(TextRect candidate, TextRect current)
             => CenterDistance(candidate, current) <= Math.Max(3, Math.Max(candidate.Width, candidate.Height) * 0.15)
@@ -2171,8 +2191,9 @@ public sealed class OcrTextTracker(ILogger<OcrTextTracker> logger) : IOcrTextTra
                 MultiLine = current.MultiLine,
                 Angle = current.Angle,
             };
-            this.geometryCandidate = null;
-            this.geometryCandidateCount = 0;
+            this.normalGeometryCandidate = null;
+            this.normalGeometryCandidateCount = 0;
+            this.noiseGeometrySamples.Clear();
         }
 
         public TextRect ProjectOutputGeometry(TextRect previousParent, TextRect currentParent)


### PR DESCRIPTION
## 概要

- Stable を中心としたノイズ範囲の Geometry を 5 サンプル保持し、最新値ではなく代表値へ収束させるようにしました
- `X` / `Y` / `Width` / `Height` / `FontSize` は中央値、`MultiLine` は多数決、`Angle` は角度の循環を考慮した代表値を使用します
- 通常 Geometry 変更、ノイズ Geometry の収束、merge / restore の Structure 変更で確定条件を分離しました
- 通常 Geometry 候補の継続確認では `FontSize` の整合性も確認し、ノイズ範囲外の周期値を同一候補として誤確定しないようにしました
- 大きな移動の即時適用と、既存の assignment / text / structure 閾値は維持しています

## 背景

従来は Geometry 候補の確認後に最後の観測値をそのまま適用していたため、近い値が周期的に返ると安定値自体が往復することがありました。Stable をアンカーに含む代表値方式にすることで、周期ノイズとノイズ範囲内の単発外れ値を抑えつつ、継続する小さな実変化には追従します。

また、ノイズ範囲外の候補判定に `FontSize` が含まれていなかったため、位置とサイズが同じ `40 → 10 → 40` のような周期変動を継続候補として扱う問題も修正しました。

## 影響

ノイズ範囲内の実変化は代表値が切り替わるまで最大 4 回の観測を要します。ノイズ範囲外の通常変更は、全 Geometry 値が整合する候補を従来どおり 2 回確認します。大きな移動は即時反映です。

## テスト

`dotnet test WindowTranslator.Tests\WindowTranslator.Tests.csproj --no-restore --runtime win-x64 --configuration Debug --verbosity minimal -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false --disable-build-servers`

- 84 件成功
- 周期的な位置・FontSize ノイズ
- ノイズ範囲外の FontSize 周期変動（両方の開始位相）
- ノイズ範囲内の単発外れ値
- 全 Geometry 値の継続的な小変化
- 大きな移動の即時追従

Closes #674