### PR TITLE
プラグインストアにカテゴリフィルターを追加

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://github.com/Freeesia/WindowTranslator</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Freeesia/WindowTranslator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>WindowTranslator;OCR;Translation</PackageTags>
+    <PackageTags>WindowTranslator</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugType>embedded</DebugType>

--- a/Plugins/WindowTranslator.Plugin.BergamotTranslatorPlugin/WindowTranslator.Plugin.BergamotTranslatorPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.BergamotTranslatorPlugin/WindowTranslator.Plugin.BergamotTranslatorPlugin.csproj
@@ -6,6 +6,7 @@
     <Description>Offline neural machine translation for WindowTranslator using Bergamot.</Description>
     <IsPublishable>true</IsPublishable>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);translate</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Plugins/WindowTranslator.Plugin.DeepLTranslatePlugin/WindowTranslator.Plugin.DeepLTranslatePlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.DeepLTranslatePlugin/WindowTranslator.Plugin.DeepLTranslatePlugin.csproj
@@ -4,6 +4,7 @@
     <Title>DeepL Translator Plugin</Title>
     <Description>Translation for WindowTranslator using the DeepL API.</Description>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);translate</PackageTags>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 

--- a/Plugins/WindowTranslator.Plugin.FoMPlugin/WindowTranslator.Plugin.FoMPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.FoMPlugin/WindowTranslator.Plugin.FoMPlugin.csproj
@@ -5,6 +5,7 @@
     <Description>Context-aware translation filtering for Fields of Mistria.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);filter</PackageTags>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 

--- a/Plugins/WindowTranslator.Plugin.GitHubCopilotPlugin/WindowTranslator.Plugin.GitHubCopilotPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.GitHubCopilotPlugin/WindowTranslator.Plugin.GitHubCopilotPlugin.csproj
@@ -4,6 +4,7 @@
     <Title>GitHub Copilot Translator Plugin</Title>
     <Description>Translation for WindowTranslator using GitHub Copilot.</Description>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);translate</PackageTags>
     <IsPublishable>false</IsPublishable>
     <IncludePluginRuntimeAssetsInPackage>true</IncludePluginRuntimeAssetsInPackage>
   </PropertyGroup>

--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAIOcr.cs
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/GoogleAIOcr.cs
@@ -9,6 +9,7 @@ using Windows.Graphics.Imaging;
 using WindowTranslator.Extensions;
 using WindowTranslator.Modules;
 
+#if DEBUG
 namespace WindowTranslator.Plugin.GoogleAIPlugin;
 
 [Experimental("WT0001")]
@@ -80,3 +81,4 @@ public sealed class GoogleAIOcr : IOcrModule
 
     private record Rect(int[] Box2d, string Text);
 }
+#endif

--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/WindowTranslator.Plugin.GoogleAIPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/WindowTranslator.Plugin.GoogleAIPlugin.csproj
@@ -5,12 +5,15 @@
     <Title>Google AI Plugin</Title>
     <Description>Translation, OCR, and text correction for WindowTranslator using Google AI.</Description>
     <IsPackable>true</IsPackable>
-    <PackageTags>$(PackageTags);translate;ocr;filter</PackageTags>
+    <PackageTags>$(PackageTags);translate;filter</PackageTags>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper" />
     <PackageReference Include="Google_GenerativeAI" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
+    <Compile Remove="GoogleAIOcr.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/WindowTranslator.Plugin.GoogleAIPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/WindowTranslator.Plugin.GoogleAIPlugin.csproj
@@ -5,6 +5,7 @@
     <Title>Google AI Plugin</Title>
     <Description>Translation, OCR, and text correction for WindowTranslator using Google AI.</Description>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);translate;ocr;filter</PackageTags>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>

--- a/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/WindowTranslator.Plugin.GoogleAIPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.GoogleAIPlugin/WindowTranslator.Plugin.GoogleAIPlugin.csproj
@@ -12,9 +12,6 @@
     <PackageReference Include="CsvHelper" />
     <PackageReference Include="Google_GenerativeAI" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
-    <Compile Remove="GoogleAIOcr.cs" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/Plugins/WindowTranslator.Plugin.GoogleAppsSctiptPlugin/WindowTranslator.Plugin.GoogleAppsSctiptPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.GoogleAppsSctiptPlugin/WindowTranslator.Plugin.GoogleAppsSctiptPlugin.csproj
@@ -3,6 +3,7 @@
     <Title>Google Apps Script Translator Plugin</Title>
     <Description>Translation for WindowTranslator through Google Apps Script.</Description>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);translate</PackageTags>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>

--- a/Plugins/WindowTranslator.Plugin.LLMPlugin/LLMOcr.cs
+++ b/Plugins/WindowTranslator.Plugin.LLMPlugin/LLMOcr.cs
@@ -12,6 +12,7 @@ using Windows.Graphics.Imaging;
 using WindowTranslator.Extensions;
 using WindowTranslator.Modules;
 
+#if DEBUG
 namespace WindowTranslator.Plugin.LLMPlugin;
 
 [Experimental("WT0001")]
@@ -162,3 +163,4 @@ public sealed class LLMOcr : IOcrModule
     private record Rect([property: JsonPropertyName("box_2d")] int[] Box2d, string Text);
     private record RecognizedTexts(Rect[] Texts);
 }
+#endif

--- a/Plugins/WindowTranslator.Plugin.LLMPlugin/WindowTranslator.Plugin.LLMPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.LLMPlugin/WindowTranslator.Plugin.LLMPlugin.csproj
@@ -4,6 +4,7 @@
     <Title>LLM Plugin</Title>
     <Description>Translation, OCR, and text correction through OpenAI-compatible language models.</Description>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);translate;ocr;filter</PackageTags>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>

--- a/Plugins/WindowTranslator.Plugin.LLMPlugin/WindowTranslator.Plugin.LLMPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.LLMPlugin/WindowTranslator.Plugin.LLMPlugin.csproj
@@ -4,12 +4,15 @@
     <Title>LLM Plugin</Title>
     <Description>Translation, OCR, and text correction through OpenAI-compatible language models.</Description>
     <IsPackable>true</IsPackable>
-    <PackageTags>$(PackageTags);translate;ocr;filter</PackageTags>
+    <PackageTags>$(PackageTags);translate;filter</PackageTags>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper" />
     <PackageReference Include="OpenAI" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
+    <Compile Remove="LLMOcr.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/Plugins/WindowTranslator.Plugin.LLMPlugin/WindowTranslator.Plugin.LLMPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.LLMPlugin/WindowTranslator.Plugin.LLMPlugin.csproj
@@ -11,9 +11,6 @@
     <PackageReference Include="CsvHelper" />
     <PackageReference Include="OpenAI" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
-    <Compile Remove="LLMOcr.cs" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/Plugins/WindowTranslator.Plugin.OneOcrPlugin/WindowTranslator.Plugin.OneOcrPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.OneOcrPlugin/WindowTranslator.Plugin.OneOcrPlugin.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPublishable>true</IsPublishable>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);ocr</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Panlingo.LanguageIdentification.FastText" />

--- a/Plugins/WindowTranslator.Plugin.PLaMoPlugin/WindowTranslator.Plugin.PLaMoPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.PLaMoPlugin/WindowTranslator.Plugin.PLaMoPlugin.csproj
@@ -5,6 +5,7 @@
     <Title>PLaMo Translator Plugin</Title>
     <Description>Local PLaMo translation for WindowTranslator using LLamaSharp and CUDA.</Description>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);translate</PackageTags>
     <IsPublishable>false</IsPublishable>
     <IncludePluginRuntimeAssetsInPackage>true</IncludePluginRuntimeAssetsInPackage>
     <PlatformTarget>x64</PlatformTarget>

--- a/Plugins/WindowTranslator.Plugin.TesseractOCRPlugin/WindowTranslator.Plugin.TesseractOCRPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.TesseractOCRPlugin/WindowTranslator.Plugin.TesseractOCRPlugin.csproj
@@ -5,6 +5,7 @@
     <Title>Tesseract OCR Plugin</Title>
     <Description>OCR for WindowTranslator using the Tesseract engine.</Description>
     <IsPackable>true</IsPackable>
+    <PackageTags>$(PackageTags);ocr</PackageTags>
     <IsPublishable>false</IsPublishable>
     <IncludePluginRuntimeAssetsInPackage>true</IncludePluginRuntimeAssetsInPackage>
   </PropertyGroup>

--- a/WindowTranslator.Tests/NuGetPluginServiceTests.cs
+++ b/WindowTranslator.Tests/NuGetPluginServiceTests.cs
@@ -600,6 +600,81 @@ public sealed class NuGetPluginServiceTests
     }
 
     [Fact]
+    public async Task CategoryFilterUsesCachedPackageTagsWithoutRefreshingNuGet()
+    {
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            using var handler = new InMemoryNuGetHandler();
+            handler.SearchResults =
+                [
+                    CreatePackageSearchMetadata(
+                        "Translate.Plugin",
+                        "Translate Plugin",
+                        null,
+                        null,
+                        null,
+                        null,
+                        tags: "windowtranslator-plugin Translate"),
+                    CreatePackageSearchMetadata(
+                        "Multiple.Plugin",
+                        "Multiple Plugin",
+                        null,
+                        null,
+                        null,
+                        null,
+                        tags: "windowtranslator-plugin;ocr;filter"),
+                    CreatePackageSearchMetadata(
+                        "Uncategorized.Plugin",
+                        "Uncategorized Plugin",
+                        null,
+                        null,
+                        null,
+                        null,
+                        tags: "windowtranslator-plugin"),
+                ];
+            handler.AddMetadataVersions(
+                "Translate.Plugin",
+                CreatePluginVersionMetadata("1.0.0"));
+            handler.AddMetadataVersions(
+                "Multiple.Plugin",
+                CreatePluginVersionMetadata("1.0.0"));
+            handler.AddMetadataVersions(
+                "Uncategorized.Plugin",
+                CreatePluginVersionMetadata("1.0.0"));
+            using var service = CreateService(handler, testDirectory);
+            using var viewModel = new PluginStoreViewModel(
+                service,
+                NullLogger<PluginStoreViewModel>.Instance,
+                dialogService: null!);
+
+            await service.RefreshPackageInformationAsync();
+
+            Assert.Equal(3, viewModel.FilteredPackages.Count());
+            Assert.Contains(
+                "Translate",
+                service.PackageSnapshot.Packages.Single(package => package.Id == "Translate.Plugin").Tags);
+
+            viewModel.SelectedCategory = "translate";
+            Assert.Equal("Translate.Plugin", Assert.Single(viewModel.FilteredPackages).Id);
+
+            viewModel.SelectedCategory = "ocr";
+            Assert.Equal("Multiple.Plugin", Assert.Single(viewModel.FilteredPackages).Id);
+
+            viewModel.SelectedCategory = "filter";
+            Assert.Equal("Multiple.Plugin", Assert.Single(viewModel.FilteredPackages).Id);
+
+            viewModel.SelectedCategory = string.Empty;
+            Assert.Equal(3, viewModel.FilteredPackages.Count());
+            Assert.Equal(["tags:windowtranslator-plugin"], handler.RequestedSearchTerms);
+        }
+        finally
+        {
+            DeleteTestDirectory(testDirectory);
+        }
+    }
+
+    [Fact]
     public async Task PluginStoreKeepsInstalledPackagesVisibleWhenNuGetSearchFails()
     {
         var testDirectory = CreateTestDirectory();
@@ -1967,7 +2042,8 @@ public sealed class NuGetPluginServiceTests
         bool isListed = true,
         string? readmeFileUrl = null,
         string? iconUrl = null,
-        IReadOnlyList<string>? owners = null)
+        IReadOnlyList<string>? owners = null,
+        string? tags = null)
         => new TestPackageSearchMetadata
         {
             Identity = new PackageIdentity(
@@ -1983,6 +2059,7 @@ public sealed class NuGetPluginServiceTests
             ReadmeFileUrl = readmeFileUrl!,
             IconUrl = iconUrl is null ? null! : new Uri(iconUrl),
             OwnersList = owners ?? [],
+            Tags = tags!,
         };
 
     private static async Task WaitForReadmeAsync(

--- a/WindowTranslator/Modules/PluginStore/NuGetPluginService.cs
+++ b/WindowTranslator/Modules/PluginStore/NuGetPluginService.cs
@@ -387,7 +387,13 @@ public sealed class NuGetPluginService : BackgroundService
             IconUrl: data.IconUrl?.AbsoluteUri,
             IsOfficial: data.OwnersList.Contains(
                 OfficialPackageOwner,
-                StringComparer.OrdinalIgnoreCase));
+                StringComparer.OrdinalIgnoreCase))
+        {
+            Tags = (data.Tags ?? string.Empty)
+                .Split([' ', ';', ',', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+        };
     }
 
     private bool HasCompatibleAbstractionsDependency(
@@ -586,7 +592,10 @@ public record NuGetPackageInfo(
     IReadOnlyList<string> Versions,
     string? IconUrl = null,
     bool IsOfficial = false
-);
+)
+{
+    public IReadOnlyList<string> Tags { get; init; } = [];
+}
 
 /// <summary>インストール済みパッケージ情報</summary>
 public record InstalledPackageInfo(

--- a/WindowTranslator/Modules/PluginStore/PluginStoreView.xaml
+++ b/WindowTranslator/Modules/PluginStore/PluginStoreView.xaml
@@ -49,14 +49,26 @@
             <!--  パッケージ一覧  -->
             <Grid Grid.Column="0">
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <ui:ListView
+                <ComboBox
                     Grid.Row="0"
                     Margin="4"
-                    ItemsSource="{Binding Packages}"
+                    SelectedValue="{Binding SelectedCategory, Mode=TwoWay}"
+                    SelectedValuePath="Tag">
+                    <ComboBoxItem Content="{x:Static properties:Resources.PluginCategoryAll}" Tag="" />
+                    <ComboBoxItem Content="{x:Static properties:Resources.PluginCategoryTranslate}" Tag="translate" />
+                    <ComboBoxItem Content="OCR" Tag="ocr" />
+                    <ComboBoxItem Content="{x:Static properties:Resources.PluginCategoryFilter}" Tag="filter" />
+                </ComboBox>
+
+                <ui:ListView
+                    Grid.Row="1"
+                    Margin="4"
+                    ItemsSource="{Binding FilteredPackages}"
                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                     SelectedItem="{Binding SelectedPackage}"
                     VirtualizingPanel.ScrollUnit="Pixel">
@@ -169,7 +181,7 @@
                 </ui:ListView>
 
                 <Border
-                    Grid.Row="1"
+                    Grid.Row="2"
                     Margin="4"
                     Padding="8"
                     BorderBrush="{DynamicResource SeparatorBorderBrush}"

--- a/WindowTranslator/Modules/PluginStore/PluginStoreViewModel.cs
+++ b/WindowTranslator/Modules/PluginStore/PluginStoreViewModel.cs
@@ -36,6 +36,10 @@ public partial class PluginStoreViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool requiresRestart;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(FilteredPackages))]
+    private string selectedCategory = string.Empty;
+
     public bool HasError => this.ErrorMessage is not null;
 
     public PluginPackageViewModel? SelectedPackage
@@ -69,6 +73,10 @@ public partial class PluginStoreViewModel : ObservableObject, IDisposable
 
     public ObservableCollection<PluginPackageViewModel> Packages { get; } = [];
 
+    public IEnumerable<PluginPackageViewModel> FilteredPackages => this.Packages
+        .Where(package => string.IsNullOrEmpty(this.SelectedCategory)
+            || package.Tags.Contains(this.SelectedCategory, StringComparer.OrdinalIgnoreCase));
+
     public PluginStoreViewModel(
         NuGetPluginService nugetService,
         ILogger<PluginStoreViewModel> logger,
@@ -85,6 +93,14 @@ public partial class PluginStoreViewModel : ObservableObject, IDisposable
 
     partial void OnHideDisclaimerChanged(bool value)
         => _ = SaveHideDisclaimerAsync(value);
+
+    partial void OnSelectedCategoryChanged(string value)
+    {
+        if (this.SelectedPackage is not null && !this.FilteredPackages.Contains(this.SelectedPackage))
+        {
+            this.SelectedPackage = null;
+        }
+    }
 
     private async Task SaveHideDisclaimerAsync(bool value)
     {
@@ -186,9 +202,10 @@ public partial class PluginStoreViewModel : ObservableObject, IDisposable
                 hasCompatiblePackageVersion: false));
         }
 
+        OnPropertyChanged(nameof(FilteredPackages));
         this.SelectedPackage = selectedPackageId is null
             ? null
-            : this.Packages.FirstOrDefault(package => package.Id.Equals(
+            : this.FilteredPackages.FirstOrDefault(package => package.Id.Equals(
                 selectedPackageId,
                 StringComparison.OrdinalIgnoreCase));
         this.ErrorMessage = snapshot.Error is null ? null : Resources.NuGetSearchFailed;
@@ -427,6 +444,7 @@ public partial class PluginPackageViewModel : ObservableObject
     public string Title { get; }
     public string Description { get; }
     public string Authors { get; }
+    public IReadOnlyList<string> Tags { get; }
     public string? IconUrl { get; }
     public bool IsOfficial { get; }
     public string? ReleaseVersion { get; }
@@ -508,6 +526,7 @@ public partial class PluginPackageViewModel : ObservableObject
         this.Title = info.Title;
         this.Description = info.Description;
         this.Authors = info.Authors;
+        this.Tags = info.Tags;
         this.IconUrl = info.IconUrl;
         this.IsOfficial = info.IsOfficial;
         this.ReleaseVersion = versions

--- a/WindowTranslator/Properties/Resources.Designer.cs
+++ b/WindowTranslator/Properties/Resources.Designer.cs
@@ -453,6 +453,21 @@ internal class Resources
     public static string Plugin => ResourceManager.GetString("Plugin", resourceCulture) ?? string.Empty;
 
     /// <summary>
+    /// "すべて" に類似しているローカライズされた文字列を検索します。
+    /// </summary>
+    public static string PluginCategoryAll => ResourceManager.GetString("PluginCategoryAll", resourceCulture) ?? string.Empty;
+
+    /// <summary>
+    /// "フィルター" に類似しているローカライズされた文字列を検索します。
+    /// </summary>
+    public static string PluginCategoryFilter => ResourceManager.GetString("PluginCategoryFilter", resourceCulture) ?? string.Empty;
+
+    /// <summary>
+    /// "翻訳" に類似しているローカライズされた文字列を検索します。
+    /// </summary>
+    public static string PluginCategoryTranslate => ResourceManager.GetString("PluginCategoryTranslate", resourceCulture) ?? string.Empty;
+
+    /// <summary>
     /// "インストール失敗" に類似しているローカライズされた文字列を検索します。
     /// </summary>
     public static string PluginInstallFailed => ResourceManager.GetString("PluginInstallFailed", resourceCulture) ?? string.Empty;

--- a/WindowTranslator/Properties/Resources.ar.resx
+++ b/WindowTranslator/Properties/Resources.ar.resx
@@ -513,4 +513,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>تستخدمه وحدات الترجمة التي تدعم السياق</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>الكل</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>الترجمة</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>المرشحات</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.cs.resx
+++ b/WindowTranslator/Properties/Resources.cs.resx
@@ -403,4 +403,13 @@ Monitory nejsou podporovány.
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Používají jej překladové moduly podporující kontext</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Vše</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Překlad</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Filtry</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.de.resx
+++ b/WindowTranslator/Properties/Resources.de.resx
@@ -522,4 +522,13 @@ Monitore werden nicht unterstützt.
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Wird von Übersetzungsmodulen verwendet, die Kontext unterstützen</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Alle</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Übersetzung</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.en.resx
+++ b/WindowTranslator/Properties/Resources.en.resx
@@ -544,4 +544,13 @@ Select a slightly wider area so that text is not cut off</value>
   <data name="PriorityRectTooSmall" xml:space="preserve">
     <value>The rectangle is too small. Please select again.</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Translation</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Filters</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.es.resx
+++ b/WindowTranslator/Properties/Resources.es.resx
@@ -513,4 +513,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Se utiliza en los módulos de traducción compatibles con el contexto</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Todos</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Traducción</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Filtros</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.fa.resx
+++ b/WindowTranslator/Properties/Resources.fa.resx
@@ -507,4 +507,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>توسط ماژول‌های ترجمه‌ای که از زمینه پشتیبانی می‌کنند استفاده می‌شود</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>همه</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>ترجمه</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>فیلترها</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.fil.resx
+++ b/WindowTranslator/Properties/Resources.fil.resx
@@ -522,4 +522,13 @@ Ang monitor ay hindi suportado.
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Ginagamit ng mga module ng pagsasalin na sumusuporta sa konteksto</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Lahat</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Pagsasalin</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Mga filter</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.fr.resx
+++ b/WindowTranslator/Properties/Resources.fr.resx
@@ -513,4 +513,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Utilisé par les modules de traduction prenant en charge le contexte</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Tous</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Traduction</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Filtres</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.hi.resx
+++ b/WindowTranslator/Properties/Resources.hi.resx
@@ -515,4 +515,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>संदर्भ का समर्थन करने वाले अनुवाद मॉड्यूल द्वारा उपयोग किया जाता है</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>सभी</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>अनुवाद</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>फ़िल्टर</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.hu.resx
+++ b/WindowTranslator/Properties/Resources.hu.resx
@@ -403,4 +403,13 @@ A monitorok nem támogatottak.
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>A kontextust támogató fordítási modulok használják</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Összes</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Fordítás</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Szűrők</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.id.resx
+++ b/WindowTranslator/Properties/Resources.id.resx
@@ -521,4 +521,13 @@ Monitor tidak didukung.</value>
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Digunakan oleh modul terjemahan yang mendukung konteks</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Semua</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Terjemahan</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.ko.resx
+++ b/WindowTranslator/Properties/Resources.ko.resx
@@ -522,4 +522,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>컨텍스트를 지원하는 번역 모듈에서 사용됩니다</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>전체</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>번역</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>필터</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.ms.resx
+++ b/WindowTranslator/Properties/Resources.ms.resx
@@ -521,4 +521,13 @@ Monitor tidak disokong.</value>
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Digunakan oleh modul terjemahan yang menyokong konteks</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Semua</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Terjemahan</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Penapis</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.pl.resx
+++ b/WindowTranslator/Properties/Resources.pl.resx
@@ -522,4 +522,13 @@ Monitory nie są obsługiwane.
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Używane przez moduły tłumaczeniowe obsługujące kontekst</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Wszystkie</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Tłumaczenie</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Filtry</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.pt-BR.resx
+++ b/WindowTranslator/Properties/Resources.pt-BR.resx
@@ -521,4 +521,13 @@ Monitor tidak didukung.</value>
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Usado por módulos de tradução compatíveis com contexto</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Todos</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Tradução</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Filtros</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.resx
+++ b/WindowTranslator/Properties/Resources.resx
@@ -544,4 +544,13 @@
   <data name="PluginOfficial" xml:space="preserve">
     <value>公式プラグイン</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>すべて</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>翻訳</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>フィルター</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.ru.resx
+++ b/WindowTranslator/Properties/Resources.ru.resx
@@ -513,4 +513,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Используется модулями перевода, поддерживающими контекст</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Все</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Перевод</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Фильтры</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.th.resx
+++ b/WindowTranslator/Properties/Resources.th.resx
@@ -522,4 +522,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>ใช้โดยโมดูลการแปลที่รองรับบริบท</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>ทั้งหมด</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>การแปล</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>ตัวกรอง</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.tr.resx
+++ b/WindowTranslator/Properties/Resources.tr.resx
@@ -522,4 +522,13 @@ Monitör desteklenmiyor.
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Bağlamı destekleyen çeviri modülleri tarafından kullanılır</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Tümü</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Çeviri</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Filtreler</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.vi.resx
+++ b/WindowTranslator/Properties/Resources.vi.resx
@@ -522,4 +522,13 @@ Màn hình không được hỗ trợ.
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>Được sử dụng bởi các mô-đun dịch hỗ trợ ngữ cảnh</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>Tất cả</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>Dịch thuật</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>Bộ lọc</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.zh-CN.resx
+++ b/WindowTranslator/Properties/Resources.zh-CN.resx
@@ -522,4 +522,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>由支持上下文的翻译模块使用</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>翻译</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>过滤器</value>
+  </data>
 </root>

--- a/WindowTranslator/Properties/Resources.zh-TW.resx
+++ b/WindowTranslator/Properties/Resources.zh-TW.resx
@@ -522,4 +522,13 @@
   <data name="PriorityRectKeywordDescription" xml:space="preserve">
     <value>供支援上下文的翻譯模組使用</value>
   </data>
+  <data name="PluginCategoryAll" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="PluginCategoryTranslate" xml:space="preserve">
+    <value>翻譯</value>
+  </data>
+  <data name="PluginCategoryFilter" xml:space="preserve">
+    <value>篩選器</value>
+  </data>
 </root>

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -33,7 +33,7 @@ cd WindowTranslator.Plugin.YourPlugin
     <PackageProjectUrl>https://github.com/YourName/YourPlugin</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- この タグ が必須です（アプリ内一覧への表示条件） -->
-    <PackageTags>$(PackageTags);windowtranslator-plugin</PackageTags>
+    <PackageTags>$(PackageTags);windowtranslator-plugin;translate</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
@@ -60,6 +60,28 @@ cd WindowTranslator.Plugin.YourPlugin
 > `WindowTranslator.Abstractions` の依存バージョン範囲は、インストール先の
 > WindowTranslator との互換性判定に使用されます。サポートする最も古い
 > `WindowTranslator.Abstractions` のバージョンを指定してください。
+
+### 機能カテゴリの指定
+
+`windowtranslator-plugin` はストアへの掲載用タグです。機能の分類には、実装している
+インターフェースに対応するカテゴリタグを追加してください。
+
+| カテゴリ | タグ | インターフェース |
+|---|---|---|
+| 翻訳 | `translate` | `ITranslateModule` |
+| OCR | `ocr` | `IOcrModule` |
+| フィルター | `filter` | `IFilterModule` |
+
+複数の機能を提供するパッケージには、複数のカテゴリタグを指定できます。
+たとえば、翻訳・OCR・フィルターを提供する場合は次のように指定します。
+
+```xml
+<PackageTags>$(PackageTags);windowtranslator-plugin;translate;ocr;filter</PackageTags>
+```
+
+カテゴリタグだけではストアに掲載されません。カテゴリタグを持たないパッケージは
+「すべて」に表示されます。カテゴリは取得済みのパッケージ情報から絞り込まれるため、
+選択を変更してもNuGetの再検索は行いません。
 
 ### README の多言語化
 


### PR DESCRIPTION
Closes #690

プラグインストアで機能カテゴリを選択し、取得済みのパッケージ一覧をローカルで絞り込めるようにします。

## 変更内容

- NuGet パッケージのタグを保持し、「すべて」「翻訳」「OCR」「フィルター」で一覧を絞り込む処理を追加
- 複数カテゴリと大文字小文字を区別しないタグ判定に対応し、カテゴリ変更時の NuGet 再検索を回避
- 各ストア配布プラグインに `translate` / `ocr` / `filter` タグを実装機能に応じて設定し、共通の `OCR` / `Translation` タグを削除
- Google AI と LLM の検証用OCR実装を `#if DEBUG` で囲み、Debugビルドだけで有効化して公開カテゴリから除外
- カテゴリ選択肢を22言語のリソースへ追加
- カテゴリタグの付け方と複数カテゴリの指定方法を `docs/plugin.md` に追記

## 検証

- `WindowTranslator` の Debug ビルド成功（既存の CS9336 警告1件）
- Google AI / LLM プラグインのDebug・Releaseビルド成功
- 生成DLLを確認し、両プラグインのOCR型がDebugに存在しReleaseには存在しないことを確認
- 追加したカテゴリ絞り込みテスト成功
- `WindowTranslator.Tests` 全体: 141件成功、1件失敗
  - 失敗は既存の `DependencyWithIncompatibleLibStillInstallsCompatibleNativeAssets`
  - 現在の master のインストーラーが native asset を平坦化する一方、テストが入れ子のパスを期待しているためで、今回の差分とは無関係
- 全プラグインの `PackageTags` 評価結果を確認
- 22個の resx の XML と追加キーを確認
- `git diff --check` 成功