### PR TITLE
ユーザープラグインを最優先で読み込む

### DIFF
--- a/WindowTranslator.Tests/NuGetPluginServiceTests.cs
+++ b/WindowTranslator.Tests/NuGetPluginServiceTests.cs
@@ -1656,6 +1656,75 @@ public sealed class NuGetPluginServiceTests
     }
 
     [Fact]
+    public async Task NestedPrioritizedCatalogUsesUserThenNuGetThenBundled()
+    {
+        var allAssemblyName = $"All.Plugin.{Guid.NewGuid():N}";
+        var userNugetAssemblyName = $"UserNuGet.Plugin.{Guid.NewGuid():N}";
+        var userBundledAssemblyName = $"UserBundled.Plugin.{Guid.NewGuid():N}";
+        var nugetBundledAssemblyName = $"NuGetBundled.Plugin.{Guid.NewGuid():N}";
+        var userAllType = CreatePluginTypes(allAssemblyName, "User.AllPlugin")[0];
+        var userNugetType = CreatePluginTypes(userNugetAssemblyName, "User.UserNuGetPlugin")[0];
+        var userBundledType = CreatePluginTypes(userBundledAssemblyName, "User.UserBundledPlugin")[0];
+        var userOnlyType = CreatePluginTypes(
+            $"User.Plugin.{Guid.NewGuid():N}",
+            "User.UserOnlyPlugin")[0];
+        var userSameTypeName = CreatePluginTypes(
+            $"User.SameName.Plugin.{Guid.NewGuid():N}",
+            "User.SamePlugin")[0];
+        var nugetAllType = CreatePluginTypes(allAssemblyName, "NuGet.AllPlugin")[0];
+        var nugetUserType = CreatePluginTypes(userNugetAssemblyName, "NuGet.UserNuGetPlugin")[0];
+        var nugetBundledType = CreatePluginTypes(nugetBundledAssemblyName, "NuGet.NuGetBundledPlugin")[0];
+        var nugetOnlyType = CreatePluginTypes(
+            $"NuGet.Plugin.{Guid.NewGuid():N}",
+            "NuGet.NuGetOnlyPlugin")[0];
+        var bundledAllType = CreatePluginTypes(allAssemblyName, "Bundled.AllPlugin")[0];
+        var bundledUserType = CreatePluginTypes(userBundledAssemblyName, "Bundled.UserBundledPlugin")[0];
+        var bundledNugetType = CreatePluginTypes(nugetBundledAssemblyName, "Bundled.NuGetBundledPlugin")[0];
+        var bundledOnlyType = CreatePluginTypes(
+            $"Bundled.Plugin.{Guid.NewGuid():N}",
+            "Bundled.BundledOnlyPlugin")[0];
+        var bundledSameTypeName = CreatePluginTypes(
+            $"Bundled.SameName.Plugin.{Guid.NewGuid():N}",
+            "Bundled.SamePlugin")[0];
+        var userCatalog = new TestPluginCatalog(
+            userAllType,
+            userNugetType,
+            userBundledType,
+            userOnlyType,
+            userSameTypeName);
+        var nugetCatalog = new TestPluginCatalog(
+            nugetAllType,
+            nugetUserType,
+            nugetBundledType,
+            nugetOnlyType);
+        var bundledCatalog = new TestPluginCatalog(
+            bundledAllType,
+            bundledUserType,
+            bundledNugetType,
+            bundledOnlyType,
+            bundledSameTypeName);
+        var catalog = new PrioritizedPluginCatalog(
+            userCatalog,
+            new PrioritizedPluginCatalog(nugetCatalog, bundledCatalog));
+
+        await catalog.Initialize();
+
+        Assert.Equal(
+            [
+                userAllType,
+                userNugetType,
+                userBundledType,
+                userOnlyType,
+                userSameTypeName,
+                nugetBundledType,
+                nugetOnlyType,
+                bundledOnlyType,
+                bundledSameTypeName,
+            ],
+            catalog.GetPlugins().Select(plugin => plugin.Type));
+    }
+
+    [Fact]
     public async Task CatalogLoadsARealAssemblyFromAPackageSubdirectory()
     {
         var sourceDirectory = CreateTestDirectory();

--- a/WindowTranslator/Program.cs
+++ b/WindowTranslator/Program.cs
@@ -123,23 +123,18 @@ IPluginCatalog pluginFolderCatalog = new NuGetPluginCatalog(
     AppInfo.Instance.Version.Major,
     hostPackageVersions[NuGetPluginService.AbstractionsPackageId],
     new() { PluginNameOptions = { PluginNameGenerator = GetPluginName } });
-var fallbackPluginCatalogs = new List<IPluginCatalog>();
 var appPluginDir = @".\plugins";
 if (Directory.Exists(appPluginDir))
 {
-    fallbackPluginCatalogs.Add(
+    pluginFolderCatalog = new PrioritizedPluginCatalog(
+        pluginFolderCatalog,
         new FolderPluginCatalog(appPluginDir, options: new() { PluginNameOptions = { PluginNameGenerator = GetPluginName } }));
 }
 if (Directory.Exists(userPluginsDir))
 {
-    fallbackPluginCatalogs.Add(
-        new FolderPluginCatalog(userPluginsDir, options: new() { PluginNameOptions = { PluginNameGenerator = GetPluginName } }));
-}
-if (fallbackPluginCatalogs.Count > 0)
-{
     pluginFolderCatalog = new PrioritizedPluginCatalog(
-        pluginFolderCatalog,
-        new CompositePluginCatalog([.. fallbackPluginCatalogs]));
+        new FolderPluginCatalog(userPluginsDir, options: new() { PluginNameOptions = { PluginNameGenerator = GetPluginName } }),
+        pluginFolderCatalog);
 }
 
 builder.Services.AddPluginCatalog(pluginFolderCatalog);


### PR DESCRIPTION
## 概要

ユーザーが手動配置したプラグインを、Plugin Store版やアプリ同梱版より優先して読み込めるようにします。

## 変更内容

- プラグインカタログを `UserDir\plugins > UserDir\nuget-plugins > .\plugins` の順にネスト
- 既存の Assembly Name 単位の重複除外仕様を維持
- 3段階の優先度と重複パターンを回帰テストで検証

## テスト

- 優先度関連テスト: 2件合格
- 全体: 141件合格、`DependencyWithIncompatibleLibStillInstallsCompatibleNativeAssets` は既存のネイティブ資産欠落で失敗

Closes #693