### PR TITLE
FastText破棄競合によるクラッシュを修正

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="NuGet.Versioning" Version="7.6.0" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
-    <PackageVersion Include="Panlingo.LanguageIdentification.FastText" Version="0.6.2" />
+    <PackageVersion Include="Panlingo.LanguageIdentification.FastText" Version="0.8.0" />
     <PackageVersion Include="PropertyTools" Version="3.1.0" />
     <PackageVersion Include="PropertyTools.Wpf" Version="3.1.0" />
     <PackageVersion Include="Quickenshtein" Version="1.5.1" />


### PR DESCRIPTION
## 概要
設定再適用時、実行中の OCR が使用している FastText ネイティブ detector を旧スコープの破棄処理が解放し、プロセスがクラッシュする競合を修正します。

## 変更内容
- `Panlingo.LanguageIdentification.FastText` を 0.6.2 から 0.8.0 に更新
- 0.8.0 に含まれる、予測中の detector を破棄せず処理完了まで待機するライフタイム制御を利用

## 検証
- `dotnet restore Plugins\WindowTranslator.Plugin.OneOcrPlugin\WindowTranslator.Plugin.OneOcrPlugin.csproj`
- `dotnet build Plugins\WindowTranslator.Plugin.OneOcrPlugin\WindowTranslator.Plugin.OneOcrPlugin.csproj --no-restore --disable-build-servers`
- ビルド成功（0エラー、既存の無関係な CS9336 警告1件）