### PR TITLE
FoMのローカライズをassets.zipから読み込む

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,6 +50,7 @@
     <PackageVersion Include="System.Drawing.Common" Version="10.0.0" />
     <PackageVersion Include="System.Interactive" Version="6.0.3" />
     <PackageVersion Include="TesseractOCR" Version="5.5.1" />
+    <PackageVersion Include="Tomlyn" Version="2.10.1" />
     <PackageVersion Include="ValueTaskSupplement" Version="1.1.0" />
     <PackageVersion Include="Wacton.Unicolour" Version="6.3.0" />
     <PackageVersion Include="Weikio.PluginFramework.AspNetCore" Version="1.5.1" />

--- a/Plugins/WindowTranslator.Plugin.FoMPlugin/FoMFilterModule.cs
+++ b/Plugins/WindowTranslator.Plugin.FoMPlugin/FoMFilterModule.cs
@@ -1,10 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Diagnostics;
-using System.Text.Encodings.Web;
-using System.Text.Json;
 using System.Text.RegularExpressions;
-using System.Text.Unicode;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -16,11 +13,6 @@ namespace WindowTranslator.Plugin.FoMPlugin;
 
 public partial class FoMFilterModule : IFilterModule
 {
-    private static readonly JsonSerializerOptions serializerOptions = new()
-    {
-        Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
-        PropertyNameCaseInsensitive = true,
-    };
     private readonly bool isEnabled;
     private readonly bool useJpn;
     private readonly bool exclude;
@@ -286,29 +278,22 @@ public partial class FoMFilterModule : IFilterModule
         {
             return;
         }
-
-
-        this.isEnabled = true;
-        this.useJpn = options.Value.UseJpn;
-        var path = Path.Combine(Path.GetDirectoryName(exePath)!, "localization.json");
-        if (!File.Exists(path))
+        var loc = FoMLocalization.Load(Path.Combine(Path.GetDirectoryName(exePath)!, "assets.zip"));
+        if (loc is null)
         {
             return;
         }
-        using var fs = File.OpenRead(path);
-        var loc = JsonSerializer.Deserialize<Localization>(fs, serializerOptions) ?? new([], []);
-        if (loc.Eng is null)
-        {
-            loc = loc with { Eng = [] };
-        }
-        if (loc.Jpn is null)
+
+        this.isEnabled = true;
+        this.useJpn = options.Value.UseJpn;
+        if (loc.Jpn.Count == 0)
         {
             loc = loc with { Jpn = names };
         }
         var player = options.Value.PlayerName;
         var farm = options.Value.FarmName;
         this.exclude = options.Value.ExcludeUnspecifiedText;
-        this.builtin = loc!.Eng
+        this.builtin = loc.Eng
             .Select(p => (
                 en: p.Value.ReplaceToPlain(player, farm),
                 ja: new LocInto(p.Key, loc.Jpn.TryGetValue(p.Key, out var s) ? s.CorrenctJpn().ReplaceToPlain(player, farm) : string.Empty)))
@@ -578,7 +563,7 @@ public partial class FoMFilterModule : IFilterModule
         => keys is ["Conversations" or "Cutscenes", _, var c, ..] ? GetCharContext(c) : string.Empty;
 }
 
-record Localization(Dictionary<string, string> Eng, Dictionary<string, string>? Jpn);
+record Localization(Dictionary<string, string> Eng, Dictionary<string, string> Jpn);
 record LocInto(string Key, string Text);
 
 record CacheInfo(string[] Keys, string En, string Ja, string CharContext, string SceneContext);

--- a/Plugins/WindowTranslator.Plugin.FoMPlugin/FoMLocalization.cs
+++ b/Plugins/WindowTranslator.Plugin.FoMPlugin/FoMLocalization.cs
@@ -1,0 +1,289 @@
+using System.IO.Compression;
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace WindowTranslator.Plugin.FoMPlugin;
+
+internal static class FoMLocalization
+{
+    private const string LocalizationManifestEntryName = "assets/localization/l10n.meta.toml";
+    private const string JapaneseTranslationEntryName = "assets/localization/translations/jpn.meta.toml";
+    private const string T2EntryPrefix = "assets/t2/";
+    private const string ConversationEntrySuffix = ".c.toml";
+    private const string FiddleEntryPrefix = "assets/fiddle/";
+    private const string TomlEntrySuffix = ".toml";
+
+    public static Localization? Load(string archivePath)
+    {
+        if (!File.Exists(archivePath))
+        {
+            return null;
+        }
+
+        using var stream = File.OpenRead(archivePath);
+        return Load(stream);
+    }
+
+    internal static Localization? Load(Stream stream)
+    {
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
+        var fiddleRenames = ReadFiddleRenames(archive.GetEntry(LocalizationManifestEntryName));
+        if (fiddleRenames is null)
+        {
+            return null;
+        }
+
+        var eng = new Dictionary<string, string>(StringComparer.Ordinal);
+        ReadT2Localization(archive, eng);
+        ReadFiddleLocalization(archive, fiddleRenames, eng);
+        if (eng.Count == 0)
+        {
+            return null;
+        }
+
+        return new(eng, ReadAssetProperties(archive.GetEntry(JapaneseTranslationEntryName)) ?? []);
+    }
+
+    private static Dictionary<string, string[]>? ReadFiddleRenames(ZipArchiveEntry? entry)
+    {
+        var document = ReadToml(entry);
+        if (document?["asset_properties"] is not TomlTable assetProperties ||
+            assetProperties["fiddle_renames"] is not TomlTable fiddleRenames)
+        {
+            return null;
+        }
+
+        return fiddleRenames
+            .Where(property => property.Value is TomlArray)
+            .ToDictionary(
+                property => property.Key,
+                property => ((TomlArray)property.Value).OfType<string>().ToArray(),
+                StringComparer.Ordinal);
+    }
+
+    private static void ReadT2Localization(ZipArchive archive, Dictionary<string, string> localization)
+    {
+        foreach (var entry in archive.Entries.Where(entry =>
+                     entry.FullName.StartsWith(T2EntryPrefix, StringComparison.Ordinal) &&
+                     entry.FullName.EndsWith(ConversationEntrySuffix, StringComparison.Ordinal)))
+        {
+            var document = ReadToml(entry);
+            if (document is null)
+            {
+                continue;
+            }
+
+            var fileKey = entry.FullName[T2EntryPrefix.Length..^ConversationEntrySuffix.Length];
+            foreach (var conversation in document.Where(property => property.Value is TomlTable))
+            {
+                var conversationKey = $"{fileKey}/{conversation.Key}";
+                var conversationTable = (TomlTable)conversation.Value;
+                ReadConversationEntry(conversationTable, conversationKey, "init", localization);
+
+                foreach (var sequence in conversationTable.Where(property => property.Value is TomlTable))
+                {
+                    ReadConversationEntry((TomlTable)sequence.Value, conversationKey, sequence.Key, localization);
+                }
+            }
+        }
+    }
+
+    private static void ReadConversationEntry(
+        TomlTable entry,
+        string conversationKey,
+        string sequenceKey,
+        Dictionary<string, string> localization)
+    {
+        if (entry.TryGetValue("local", out var local))
+        {
+            AddConversationText(localization, $"{conversationKey}/{sequenceKey}", local);
+        }
+
+        if (entry.TryGetValue("prompts", out var prompts))
+        {
+            var index = 0;
+            foreach (var prompt in EnumerateTables(prompts))
+            {
+                if (prompt.TryGetValue("local", out var promptLocal) &&
+                    promptLocal is string text)
+                {
+                    localization[$"{conversationKey}/{sequenceKey}/prompts/{index}"] = text;
+                }
+
+                index++;
+            }
+        }
+    }
+
+    private static IEnumerable<TomlTable> EnumerateTables(object? value)
+    {
+        switch (value)
+        {
+            case TomlArray array:
+                foreach (var table in array.OfType<TomlTable>())
+                {
+                    yield return table;
+                }
+                break;
+
+            case TomlTableArray tableArray:
+                foreach (var table in tableArray)
+                {
+                    yield return table;
+                }
+                break;
+        }
+    }
+
+    private static void AddConversationText(
+        Dictionary<string, string> localization,
+        string key,
+        object? value)
+    {
+        if (value is string text)
+        {
+            localization[key] = text;
+            return;
+        }
+
+        if (value is not TomlArray sequence)
+        {
+            return;
+        }
+
+        for (var index = 0; index < sequence.Count; index++)
+        {
+            if (sequence[index] is not string sequenceText)
+            {
+                continue;
+            }
+
+            var sequenceKey = index == 0 ? key : $"{key}$_sequence_entry_{index}$";
+            localization[sequenceKey] = sequenceText;
+        }
+    }
+
+    private static void ReadFiddleLocalization(
+        ZipArchive archive,
+        IReadOnlyDictionary<string, string[]> fiddleRenames,
+        Dictionary<string, string> localization)
+    {
+        foreach (var (source, patterns) in fiddleRenames)
+        {
+            foreach (var entry in GetFiddleEntries(archive, source))
+            {
+                var document = ReadToml(entry);
+                if (document is null)
+                {
+                    continue;
+                }
+
+                var fileKey = entry.FullName[FiddleEntryPrefix.Length..^TomlEntrySuffix.Length];
+                foreach (var (propertyPath, value) in EnumerateStrings(document))
+                {
+                    if (patterns.Any(pattern => MatchesPattern(propertyPath, pattern)))
+                    {
+                        localization[$"{fileKey}/{propertyPath}"] = value;
+                    }
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<ZipArchiveEntry> GetFiddleEntries(ZipArchive archive, string source)
+    {
+        var path = source.TrimEnd('/');
+        if (!source.EndsWith("/", StringComparison.Ordinal))
+        {
+            var exactEntry = archive.GetEntry($"{FiddleEntryPrefix}{path}{TomlEntrySuffix}");
+            if (exactEntry is not null)
+            {
+                yield return exactEntry;
+                yield break;
+            }
+        }
+
+        var directoryPrefix = $"{FiddleEntryPrefix}{path}/";
+        foreach (var entry in archive.Entries.Where(entry =>
+                     entry.FullName.StartsWith(directoryPrefix, StringComparison.Ordinal) &&
+                     entry.FullName.EndsWith(TomlEntrySuffix, StringComparison.Ordinal)))
+        {
+            yield return entry;
+        }
+    }
+
+    private static IEnumerable<(string Path, string Value)> EnumerateStrings(object? value, string path = "")
+    {
+        switch (value)
+        {
+            case string text:
+                yield return (path, text);
+                break;
+
+            case TomlTable table:
+                foreach (var property in table)
+                {
+                    var childPath = string.IsNullOrEmpty(path) ? property.Key : $"{path}/{property.Key}";
+                    foreach (var item in EnumerateStrings(property.Value, childPath))
+                    {
+                        yield return item;
+                    }
+                }
+                break;
+
+            case TomlArray array:
+                for (var index = 0; index < array.Count; index++)
+                {
+                    var childPath = string.IsNullOrEmpty(path) ? index.ToString() : $"{path}/{index}";
+                    foreach (var item in EnumerateStrings(array[index], childPath))
+                    {
+                        yield return item;
+                    }
+                }
+                break;
+
+            case TomlTableArray tableArray:
+                for (var index = 0; index < tableArray.Count; index++)
+                {
+                    var childPath = string.IsNullOrEmpty(path) ? index.ToString() : $"{path}/{index}";
+                    foreach (var item in EnumerateStrings(tableArray[index], childPath))
+                    {
+                        yield return item;
+                    }
+                }
+                break;
+        }
+    }
+
+    private static bool MatchesPattern(string propertyPath, string pattern)
+    {
+        var pathParts = propertyPath.Split('/');
+        var patternParts = pattern.Split('/');
+        return pathParts.Length == patternParts.Length &&
+               pathParts.Zip(patternParts).All(parts => parts.Second == "*" || parts.First == parts.Second);
+    }
+
+    private static Dictionary<string, string>? ReadAssetProperties(ZipArchiveEntry? entry)
+    {
+        var document = ReadToml(entry);
+        if (document?["asset_properties"] is not TomlTable properties)
+        {
+            return null;
+        }
+
+        return properties
+            .Where(property => property.Value is string)
+            .ToDictionary(property => property.Key, property => (string)property.Value!, StringComparer.Ordinal);
+    }
+
+    private static TomlTable? ReadToml(ZipArchiveEntry? entry)
+    {
+        if (entry is null)
+        {
+            return null;
+        }
+
+        using var stream = entry.Open();
+        return TomlSerializer.Deserialize<TomlTable>(stream);
+    }
+}

--- a/Plugins/WindowTranslator.Plugin.FoMPlugin/README.md
+++ b/Plugins/WindowTranslator.Plugin.FoMPlugin/README.md
@@ -7,7 +7,7 @@
 ## 機能
 
 - 実行中の`FieldsOfMistria.exe`を検出した場合だけ有効化
-- ゲームの`localization.json`を参照してOCR結果を補正
+- ゲームの`assets.zip`内にある現在の英語原文と日本語翻訳を直接参照してOCR結果を補正
 - キャラクター、シーン、会話の情報を翻訳コンテキストとして追加
 - キャラクター名やアイテム名を選択中の翻訳モジュールへ用語集として登録
 
@@ -27,7 +27,7 @@ A filter plugin that adapts [WindowTranslator](https://github.com/Freeesia/Windo
 ## Features
 
 - Activates only while `FieldsOfMistria.exe` is running
-- Corrects OCR results using the game's `localization.json`
+- Corrects OCR results using the current English source text and Japanese translations directly from the game's `assets.zip`
 - Adds character, scene, and dialogue information to the translation context
 - Registers character and item names as glossary entries with the selected translation module
 

--- a/Plugins/WindowTranslator.Plugin.FoMPlugin/WindowTranslator.Plugin.FoMPlugin.csproj
+++ b/Plugins/WindowTranslator.Plugin.FoMPlugin/WindowTranslator.Plugin.FoMPlugin.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Quickenshtein" />
+    <PackageReference Include="Tomlyn" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概要

- 旧形式の `localization.json` への依存を廃止し、ゲームの `assets.zip` からローカライズデータを直接読み込むように変更
- `assets/t2/**/*.c.toml` から会話・カットシーン、`assets/fiddle/**/*.toml` からその他の英語原文を取得
- `assets/localization/l10n.meta.toml` の `fiddle_renames` に従って対象リソースを選択
- アプリの翻訳先がゲーム対応言語の場合、その言語の `assets/localization/translations/*.meta.toml` を参照
- 対応する翻訳リソースを未翻訳候補の判定、翻訳例コンテキスト、用語集に利用し、公式翻訳は `TranslatedText` として直接返さない
- 同じ英文に複数のリソース候補がある場合もすべて保持し、翻訳先言語で英語のまま残る未翻訳候補を優先
- ゲームデータから話者を取得し、キャラクターとシーンの情報を翻訳コンテキストへ反映
- 選択肢はプレイヤー（Ari）の発言として扱い、OCR補正も未翻訳候補を中心に照合

## 対応する翻訳リソース

- 日本語 (`jpn`)
- フランス語 (`fra`)
- 韓国語 (`kor`)
- ロシア語 (`rus`)
- スペイン語 (`spa`)
- 中国語・簡体字 (`zh-Hans`)
- 中国語・繁体字 (`zh-Hant`)

英語およびゲーム非対応の翻訳先では翻訳リソースによる絞り込みを行わず、英語原文全体を補正候補にします。

## 入出力・設定

- フィルタープラグインの入力・出力型と呼び出し方法は変更なし
- 公式日本語を直接返さなくなったため、`UseJpn` 設定を削除
- プラグイン独自の言語設定は追加せず、アプリの翻訳先言語を使用

## 検証

- `dotnet build Plugins/WindowTranslator.Plugin.FoMPlugin/WindowTranslator.Plugin.FoMPlugin.csproj --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- 実際の `assets.zip` から英語 44,054 件を読み込み
- 翻訳リソースの読み込み件数: 日本語 34,176、フランス語 42,256、韓国語 43,275、ロシア語 38,163、スペイン語 38,186、簡体字 43,282、繁体字 43,275
- 会話・カットシーン 34,559 件中 33,433 件（96.7%）で話者メタデータを取得
- 翻訳済みと未翻訳が混在する同一英文 236 グループを確認
- 自動テストは要望に従い追加・実行していません
